### PR TITLE
perf: no refresh loader on new bookmark

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,7 @@ import {
   Meta,
   Outlet,
   Scripts,
+  ShouldReloadFunction,
   useMatches,
   useTransition,
 } from "@remix-run/react";
@@ -63,6 +64,10 @@ export const meta: MetaFunction = () => {
   };
 };
 
+//
+// loader
+//
+
 export const loader = makeLoader(Controller, async function () {
   const data: RootLoaderData = {
     currentUser: await this.currentUser(),
@@ -72,6 +77,17 @@ export const loader = makeLoader(Controller, async function () {
   };
   return this.serialize(data);
 });
+
+export const unstable_shouldReload: ShouldReloadFunction = ({ submission }) => {
+  if (submission?.action === R["/bookmarks/new"]) {
+    return false;
+  }
+  return true;
+};
+
+//
+// component
+//
 
 export default function DefaultComponent() {
   return (

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -1,5 +1,11 @@
 import { Transition } from "@headlessui/react";
-import { Form, Link, useFetcher, useLoaderData } from "@remix-run/react";
+import {
+  Form,
+  Link,
+  ShouldReloadFunction,
+  useFetcher,
+  useLoaderData,
+} from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
 import * as React from "react";
 import { Bookmark, MoreVertical, Play, Repeat, X } from "react-feather";
@@ -60,6 +66,13 @@ export const loader = makeLoader(Controller, async function () {
   });
   return redirect(R["/"]);
 });
+
+export const unstable_shouldReload: ShouldReloadFunction = ({ submission }) => {
+  if (submission?.action === R["/bookmarks/new"]) {
+    return false;
+  }
+  return true;
+};
 
 //
 // component


### PR DESCRIPTION
### before

```
[dev] POST /bookmarks/new?_data=routes%2Fbookmarks%2Fnew 200 - - 19.017 ms
[dev] GET /videos/26?_data=root 200 - - 9.534 ms
[dev] GET /videos/26?_data=routes%2Fvideos%2F%24id 200 - - 11.649 ms
```

### after

```
[dev] POST /bookmarks/new?_data=routes%2Fbookmarks%2Fnew 200 - - 12.459 ms
```

