### PR TITLE
refactor: write knex migrations in typescript

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,3 +1,8 @@
+// Allow writing migration files in typescript
+if (process.argv[1].endsWith("knex/bin/cli.js")) {
+  require("esbuild-register");
+}
+
 const NODE_ENV = process.env.NODE_ENV ?? "development";
 
 function env(key) {
@@ -21,6 +26,8 @@ module.exports = {
   },
   migrations: {
     directory: "app/db/migrations",
-    stub: "misc/db/migration-stub.js",
+    stub: "misc/db/migration-stub.ts",
+    extension: "ts",
+    loadExtensions: [".js", ".ts"],
   },
 };

--- a/misc/db/migration-stub.ts
+++ b/misc/db/migration-stub.ts
@@ -1,0 +1,9 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex) {
+  await knex.raw("SELECT 1 + 1");
+}
+
+export async function down(knex: Knex) {
+  await knex.raw("SELECT 1 + 1 + 1");
+}


### PR DESCRIPTION
interesting approach but not likely to be so useful...

Also, it's possible to use `knexfile.ts` via "node options" e.g.

```sh
# environment variable
NODE_OPTIONS='-r esbuild-register' knex ...

# npx options
npx --node-options='-r esbuild-register' knex ...
```