### PR TITLE
chore: cleanup npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ based on
 ```sh
 # development
 pnpm run install-with-patch
-make docker/up db/reset db/restore # username and password are "root" and "pass"
-npm run dev:all
+make docker/up db/reset db/restore # signin by "root" and "pass"
+npm run dev
 
 # lint
 npm run lint

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "scripts": {
     "install-with-patch": "npm -C .patch run build && pnpm install",
     "clean": "rm -rf build",
-    "dev": "remix dev",
+    "dev": "npm run dev:prepare && concurrently -k 'npm:remix:dev' 'npm:tsc:dev' 'npm:tailwind:dev' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold'",
     "dev:prepare": "npm run tailwind && npm run copy-assets",
+    "dev:extra": "concurrently -k 'npm:vite'",
     "dev:all": "npm run dev:prepare && concurrently -k 'npm:dev' 'npm:tsc:dev' 'npm:tailwind:dev' 'npm:vite' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold,bgGreen.bold'",
     "copy-assets": "bash scripts/copy-assets.sh",
+    "remix:dev": "remix dev",
     "tsc": "tsc",
     "tsc:dev": "tsc --noEmit --watch --preserveWatchOutput",
     "tailwind": "tailwindcss -o \"./build/tailwind/${NODE_ENV:-development}/index.css\"",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
     },
   ],
   webServer: {
-    command: "npm run dev:prepare && PORT=3001 npm run dev",
+    command: "npm run dev:prepare && PORT=3001 npm run remix:dev",
     port: 3001,
     reuseExistingServer: true,
   },


### PR DESCRIPTION
separate `vite` to `npm run dev:extra`