### PR TITLE
fix: fix cookie session flash

### DIFF
--- a/app/routes/__tests__/videos-new.test.ts
+++ b/app/routes/__tests__/videos-new.test.ts
@@ -38,7 +38,7 @@ describe("videos/new.loader", () => {
     const resSession = await getResponseSession(res);
     expect(resSession.data).toMatchInlineSnapshot(`
       {
-        "__flash_flashMessages__": [
+        "~~flash~phase2~~flash-messages": [
           {
             "content": "Invalid input",
             "variant": "error",

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -11,9 +11,9 @@ import {
 } from "../../db/models";
 import { R } from "../../misc/routes";
 import { Controller, makeLoader } from "../../utils/controller-utils";
+import { pushFlashMessage } from "../../utils/flash-message";
 import { useDeserialize, useMemoWrap } from "../../utils/hooks";
 import { PageHandle } from "../../utils/page-handle";
-import { pushFlashMessage } from "../../utils/session-utils";
 import { CaptionEntryComponent, usePlayer } from "../videos/$id";
 
 export const handle: PageHandle = {

--- a/app/routes/users/__tests__/signout.test.ts
+++ b/app/routes/users/__tests__/signout.test.ts
@@ -20,7 +20,7 @@ describe("signout.action", () => {
       const resSession = await getResponseSession(res);
       expect(resSession.data).toMatchInlineSnapshot(`
         {
-          "__flash_flashMessages__": [
+          "~~flash~phase2~~flash-messages": [
             {
               "content": "Signed out successfuly",
               "variant": "success",

--- a/app/routes/users/signin.tsx
+++ b/app/routes/users/signin.tsx
@@ -11,12 +11,10 @@ import {
   verifySignin,
 } from "../../utils/auth";
 import { AppError } from "../../utils/errors";
+import { pushFlashMessage } from "../../utils/flash-message";
 import { useIsFormValid } from "../../utils/hooks";
 import { PageHandle } from "../../utils/page-handle";
-import {
-  pushFlashMessage,
-  withRequestSession,
-} from "../../utils/session-utils";
+import { withRequestSession } from "../../utils/session-utils";
 import { fromRequestForm } from "../../utils/url-data";
 
 export const handle: PageHandle = {
@@ -48,6 +46,10 @@ export const action: ActionFunction = withRequestSession(
     try {
       const user = await verifySignin(parsed.data);
       signinSession(session, user);
+      pushFlashMessage(session, {
+        content: `Succesfully signed in as '${user.username}'`,
+        variant: "success",
+      });
       return redirect(R["/"]);
     } catch (e) {
       if (e instanceof AppError) {

--- a/app/routes/users/signout.tsx
+++ b/app/routes/users/signout.tsx
@@ -1,10 +1,8 @@
 import { ActionFunction, redirect } from "@remix-run/server-runtime";
 import { R } from "../../misc/routes";
 import { getSessionUser, signoutSession } from "../../utils/auth";
-import {
-  pushFlashMessage,
-  withRequestSession,
-} from "../../utils/session-utils";
+import { pushFlashMessage } from "../../utils/flash-message";
+import { withRequestSession } from "../../utils/session-utils";
 
 export const action: ActionFunction = withRequestSession(
   async ({ session }) => {

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -22,11 +22,11 @@ import {
 import { assert } from "../../misc/assert";
 import { R } from "../../misc/routes";
 import { Controller, makeLoader } from "../../utils/controller-utils";
+import { pushFlashMessage } from "../../utils/flash-message";
 import { useDeserialize, useSelection } from "../../utils/hooks";
 import { useYoutubeIframeApi } from "../../utils/hooks";
 import { useLeafLoaderData, useRootLoaderData } from "../../utils/loader-utils";
 import { PageHandle } from "../../utils/page-handle";
-import { pushFlashMessage } from "../../utils/session-utils";
 import { CaptionEntry } from "../../utils/types";
 import { toForm } from "../../utils/url-data";
 import {

--- a/app/routes/videos/index.tsx
+++ b/app/routes/videos/index.tsx
@@ -5,9 +5,9 @@ import { VideoComponent } from "../../components/misc";
 import { VideoTable, tables } from "../../db/models";
 import { R } from "../../misc/routes";
 import { Controller, makeLoader } from "../../utils/controller-utils";
+import { pushFlashMessage } from "../../utils/flash-message";
 import { useDeserialize } from "../../utils/hooks";
 import { PageHandle } from "../../utils/page-handle";
-import { pushFlashMessage } from "../../utils/session-utils";
 
 export const handle: PageHandle = {
   // Saved or Created Videos?

--- a/app/routes/videos/new.tsx
+++ b/app/routes/videos/new.tsx
@@ -6,10 +6,10 @@ import { filterNewVideo, insertVideoAndCaptionEntries } from "../../db/models";
 import { R } from "../../misc/routes";
 import { Controller, makeLoader } from "../../utils/controller-utils";
 import { AppError } from "../../utils/errors";
+import { pushFlashMessage } from "../../utils/flash-message";
 import { useIsFormValid } from "../../utils/hooks";
 import { useRootLoaderData } from "../../utils/loader-utils";
 import { PageHandle } from "../../utils/page-handle";
-import { pushFlashMessage } from "../../utils/session-utils";
 import { CaptionConfig, VideoMetadata } from "../../utils/types";
 import { NEW_VIDEO_SCHEMA, fetchCaptionEntries } from "../../utils/youtube";
 import {

--- a/app/utils/flash-message.ts
+++ b/app/utils/flash-message.ts
@@ -1,0 +1,25 @@
+import { Session } from "@remix-run/server-runtime";
+import { Variant } from "../components/snackbar";
+import { getFlash, setFlash } from "./session-utils";
+
+const KEY = "flash-messages";
+
+export interface FlashMessage {
+  content: string;
+  variant?: Variant;
+}
+
+export function pushFlashMessage(
+  session: Session,
+  flashMessage: FlashMessage
+): void {
+  const current = getFlashMessages(session, "phase1");
+  setFlash(session, KEY, [...current, flashMessage]);
+}
+
+export function getFlashMessages(
+  session: Session,
+  phase: "phase1" | "phase2" = "phase2"
+): FlashMessage[] {
+  return getFlash(session, KEY, phase) ?? [];
+}

--- a/app/utils/loader-utils.ts
+++ b/app/utils/loader-utils.ts
@@ -1,7 +1,7 @@
 import { useMatches } from "@remix-run/react";
 import { UserTable } from "../db/models";
+import { FlashMessage } from "./flash-message";
 import { useDeserialize } from "./hooks";
-import { FlashMessage } from "./session-utils";
 
 export interface RootLoaderData {
   currentUser?: UserTable;

--- a/app/utils/session-utils.ts
+++ b/app/utils/session-utils.ts
@@ -1,11 +1,31 @@
 import { LoaderFunction, Session } from "@remix-run/server-runtime";
-import type { Variant } from "../components/snackbar";
 import { commitSession, getSession } from "./session.server";
 
-export async function getRequestSession(request: Request): Promise<Session> {
-  return getSession(request.headers.get("cookie"));
+// NOTE:
+//  Since loaders are called in parallel, mutating cookie session in one loader is not supposed to work when other loader still keeps `set-cookie`.
+//  The trick here allows "flash value" to be accessible to the requests immediately following the response setting such cookie.
+const FLASH_PHASE1_KEY = "~~flash~phase1~~"; // set value via phase1 key
+const FLASH_PHASE2_KEY = "~~flash~phase2~~"; // get value via phase2 key
+
+export function setFlash(session: Session, key: string, value: any): void {
+  session.set(FLASH_PHASE1_KEY + key, value);
 }
 
+export function getFlash(
+  session: Session,
+  key: string,
+  phase: "phase1" | "phase2" = "phase2"
+): any {
+  return session.get(
+    (phase === "phase1" ? FLASH_PHASE1_KEY : FLASH_PHASE2_KEY) + key
+  );
+}
+
+export async function getRequestSession(request: Request): Promise<Session> {
+  return await getSession(request.headers.get("cookie"));
+}
+
+// used for testing
 export async function getResponseSession(response: Response): Promise<Session> {
   return getSession(response.headers.get("set-cookie"));
 }
@@ -14,6 +34,16 @@ export async function withResponseSession(
   response: Response,
   session: Session
 ): Promise<Response> {
+  const data = session.data;
+  for (const key in data) {
+    if (key.startsWith(FLASH_PHASE1_KEY)) {
+      const key2 = key.replace(FLASH_PHASE1_KEY, FLASH_PHASE2_KEY);
+      session.set(key2, data[key]);
+      session.unset(key);
+    } else if (key.startsWith(FLASH_PHASE2_KEY)) {
+      session.unset(key);
+    }
+  }
   response.headers.set("set-cookie", await commitSession(session));
   return response;
 }
@@ -23,6 +53,7 @@ type LoaderFunctionWithSession = (
 ) => ReturnType<LoaderFunction>;
 
 // This cannot be exported as `session.server.ts` since the decorator will be called on client
+// TODO: migrate to `makeLoader(Controller, ...)`
 export function withRequestSession(
   loader: LoaderFunctionWithSession
 ): LoaderFunction {
@@ -34,27 +65,4 @@ export function withRequestSession(
     }
     return result;
   };
-}
-
-export function pushSession<T>(
-  session: Session,
-  key: string,
-  item: T,
-  options: { flash: boolean }
-) {
-  const pushed = [...(session.data[key] ?? []), item];
-  (options.flash ? session.flash : session.set)(key, pushed);
-}
-
-export interface FlashMessage {
-  content: string;
-  variant?: Variant;
-  // TODO: add id for testing?
-  // dataTest?: string;
-}
-
-export function pushFlashMessage(session: Session, flashMessage: FlashMessage) {
-  pushSession<FlashMessage>(session, "flashMessages", flashMessage, {
-    flash: true,
-  });
 }

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -4,6 +4,7 @@ import { env } from "../misc/env";
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({
     cookie: {
+      httpOnly: true,
       secrets: [env.APP_SESSION_SECRET],
     },
   });


### PR DESCRIPTION
Requiring root loader request to apply flash message is fundamentally problematic but the 2nd approch 

- https://github.com/hi-ogawa/ytsub-v3/pull/40

works around in an okay-ish way.