### PR TITLE
test: merge coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,13 @@ jobs:
         with:
           name: coverage-e2e
           path: coverage-e2e
-      - run: ls coverage-unit
-      - run: ls coverage-e2e
-      - name: generate coverage report
+      - name: generate report
         run: |
           mkdir -p coverage/all/tmp
           mv coverage-unit/unit coverage-e2e/e2e-client coverage-e2e/e2e-server coverage
           cp coverage/{unit,e2e-client,e2e-server}/tmp/*.json coverage/all/tmp
           npx c8 report -o coverage/all -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/all/tmp
-      - name: publish coverage report
+      - name: publish report
         run: |
           echo "== HTML PREVIEW URL =="
           echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/$(git rev-parse HEAD)/all/index.html"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - run: ls coverage-e2e
       - name: generate coverage report
         run: |
-          mkdir -p coverage/all
+          mkdir -p coverage/all/tmp
           mv coverage-unit/unit coverage-e2e/e2e-client coverage-e2e/e2e-server coverage
           cp coverage/{unit,e2e-client,e2e-server}/tmp/*.json coverage/all/tmp
           npx c8 report -o coverage/all -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/all/tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - run: npm run cli -- db:test-migrations --unit-test
       - run: npm run cli -- db:test-migrations --reversibility-test
 
-  test-publish-coverage:
+  publish-coverage-report:
     runs-on: ubuntu-20.04
     needs:
       - test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           node-version: "16.14.0"
       - run: pnpm run install-with-patch -- --frozen-lockfile
-      - run: NODE_ENV=test && npm run dev:prepare && npx remix build --sourcemap
+      - run: export NODE_ENV=test && npm run dev:prepare && npx remix build --sourcemap
       - uses: actions/download-artifact@v3
         with:
           name: coverage-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: publish coverage
         run: |
           echo "== HTML PREVIEW URL =="
-          echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/$(git rev-parse HEAD)/index.html"
+          echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/$(git rev-parse HEAD)/unit/index.html"
           echo "======================"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -92,6 +92,20 @@ jobs:
       - run: make docker/up db/recreate
       - run: npm run cli -- db:test-migrations --unit-test
       - run: npm run cli -- db:test-migrations --reversibility-test
+
+  # TODO
+  # 1. download artifacts
+  # 2. move them to single directory
+  # 3. run `c8 report`
+  #   - unit
+  #   - e2e-server
+  #   - e2e-client
+  #   - all
+  # test-publish-coverage:
+  #   runs-on: ubuntu-20.04
+  #   needs:
+  #     - test
+  #     - test-e2e
 
   lint-misc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,10 @@ jobs:
       - run: pnpm run install-with-patch -- --frozen-lockfile
       - run: make docker/up db/reset/test
       - run: npm run test:coverage
-      - name: publish coverage
-        run: |
-          echo "== HTML PREVIEW URL =="
-          echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/$(git rev-parse HEAD)/unit/index.html"
-          echo "======================"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm run test:coverage:publish -- --repo "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-unit
+          path: coverage
 
   test-e2e:
     runs-on: ubuntu-20.04
@@ -77,6 +73,10 @@ jobs:
       - run: npx playwright install --with-deps
       - run: make docker/up db/reset/test
       - run: npm run test-e2e:coverage
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-e2e
+          path: coverage
 
   test-migrations:
     runs-on: ubuntu-20.04
@@ -93,19 +93,45 @@ jobs:
       - run: npm run cli -- db:test-migrations --unit-test
       - run: npm run cli -- db:test-migrations --reversibility-test
 
-  # TODO
-  # 1. download artifacts
-  # 2. move them to single directory
-  # 3. run `c8 report`
-  #   - unit
-  #   - e2e-server
-  #   - e2e-client
-  #   - all
-  # test-publish-coverage:
-  #   runs-on: ubuntu-20.04
-  #   needs:
-  #     - test
-  #     - test-e2e
+  test-publish-coverage:
+    runs-on: ubuntu-20.04
+    needs:
+      - test
+      - test-e2e
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: "6.29.1"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.14.0"
+      - run: pnpm run install-with-patch -- --frozen-lockfile
+      - run: NODE_ENV=test && npm run dev:prepare && npx remix build --sourcemap
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-unit
+          path: coverage-unit
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-e2e
+          path: coverage-e2e
+      - run: ls coverage-unit
+      - run: ls coverage-e2e
+      - name: generate coverage report
+        run: |
+          mkdir -p coverage/all
+          mv coverage-unit/unit coverage-e2e/e2e-client coverage-e2e/e2e-server coverage
+          cp coverage/{unit,e2e-client,e2e-server}/tmp/*.json coverage/all/tmp
+          npx c8 report -o coverage/all -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/all/tmp
+      - name: publish coverage report
+        run: |
+          echo "== HTML PREVIEW URL =="
+          echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/$(git rev-parse HEAD)/all/index.html"
+          echo "======================"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          NODE_DEBUG=gh-pages npx gh-pages --add --branch __coverage__ --dist coverage --dest $(git rev-parse HEAD) --repo "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
 
   lint-misc:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,23 @@
 # tools
 #
 SHELLCHECK ?= docker run --rm -v $(PWD):/mnt:ro koalaman/shellcheck:v0.7.2
+SCHEMACHECK ?= docker run --rm -i hiogawa/schemacheck # https://github.com/hi-ogawa/dockerfiles/blob/master/schemacheck/README.md
 
 #
 # lint
 #
 
-lint/all: lint/docker-compose lint/shellcheck
+lint/all: lint/docker-compose lint/shellcheck lint/github-workflow
 
 lint/docker-compose:
 	docker-compose config -q
 
 lint/shellcheck:
 	$(SHELLCHECK) scripts/*.sh
+
+lint/github-workflow:
+	$(SCHEMACHECK) -s github-workflow -y < .github/workflows/ci.yml
+	$(SCHEMACHECK) -s github-workflow -y < .github/workflows/health-check.yml
 
 #
 # db

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm run netlify:build:deploy
 
 # testing (vitest)
 npm run test
-npm run test:coverage # view result e.g. via `xdg-open coverage/index.html`
+npm run test:coverage # view result e.g. via `xdg-open coverage/unit/index.html`
 
 # testing (playwright)
 npx playwright install

--- a/app/__e2e__/coverage.ts
+++ b/app/__e2e__/coverage.ts
@@ -21,7 +21,7 @@ export const test = testDefault.extend({
     let entries = await page.coverage.stopJSCoverage();
     entries = entries.map(preprocessCoverageEntry);
     const id = sha256([testInfo.file, ...testInfo.titlePath].join("@"), "hex");
-    const outfile = path.resolve("coverage", "tmp-client", id + ".json");
+    const outfile = path.resolve("coverage", "e2e-client", "tmp", id + ".json");
     await fse.ensureDir(path.dirname(outfile));
     await fse.writeFile(outfile, JSON.stringify({ result: entries }));
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:all": "npm run dev:prepare && concurrently -k 'npm:dev' 'npm:tsc:dev' 'npm:tailwind:dev' 'npm:vite' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold,bgGreen.bold'",
     "copy-assets": "bash scripts/copy-assets.sh",
     "remix:dev": "remix dev",
-    "remix:dev:coverage": "c8 -r text -r html --all --src app --exclude build --exclude packages --exclude-after-remap node_modules/.bin/remix dev",
+    "remix:dev:coverage": "c8 -o coverage/e2e-server -r text -r html --all --src app --exclude build --exclude packages --exclude-after-remap node_modules/.bin/remix dev",
     "tsc": "tsc",
     "tsc:dev": "tsc --noEmit --watch --preserveWatchOutput",
     "tailwind": "tailwindcss -o \"./build/tailwind/${NODE_ENV:-development}/index.css\"",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:all": "npm run dev:prepare && concurrently -k 'npm:dev' 'npm:tsc:dev' 'npm:tailwind:dev' 'npm:vite' -c 'bgBlue.bold,bgYellow.bold,bgMagenta.bold,bgGreen.bold'",
     "copy-assets": "bash scripts/copy-assets.sh",
     "remix:dev": "remix dev",
-    "remix:dev:coverage": "c8 -o coverage/e2e-server -r text -r html --all --src app --exclude build --exclude packages --exclude-after-remap node_modules/.bin/remix dev",
+    "remix:dev:coverage": "c8 -o coverage/e2e-server -r text -r html --exclude build --exclude packages --exclude-after-remap node_modules/.bin/remix dev",
     "tsc": "tsc",
     "tsc:dev": "tsc --noEmit --watch --preserveWatchOutput",
     "tailwind": "tailwindcss -o \"./build/tailwind/${NODE_ENV:-development}/index.css\"",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test": "NODE_ENV=test vitest --run",
     "test:watch": "NODE_ENV=test vitest",
     "test:coverage": "NODE_ENV=test vitest --run --coverage",
-    "test:coverage:publish": "NODE_DEBUG=gh-pages gh-pages --add --branch __coverage__ --dist coverage --dest $(git rev-parse HEAD)",
     "test-e2e": "NODE_ENV=test playwright test",
     "test-e2e:debug": "NODE_ENV=test PWDEBUG=1 playwright test",
     "test-e2e:headed": "NODE_ENV=test E2E_HEADED=1 playwright test",

--- a/scripts/test-e2e-coverage.sh
+++ b/scripts/test-e2e-coverage.sh
@@ -28,5 +28,5 @@ wait "$coverage_pid"
 # print logs
 cat "$log_file"
 
-# print client coverage (TODO: merge all coverage info)
-npx c8 report -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/tmp-client
+# print client coverage
+npx c8 report -o coverage/e2e-client -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/e2e-client/tmp

--- a/scripts/test-e2e-coverage.sh
+++ b/scripts/test-e2e-coverage.sh
@@ -29,4 +29,4 @@ wait "$coverage_pid"
 cat "$log_file"
 
 # print client coverage
-npx c8 report -o coverage/e2e-client -r text -r html --all --src app --exclude build --exclude-after-remap --temp-directory coverage/e2e-client/tmp
+npx c8 report -o coverage/e2e-client -r text -r html --exclude build --exclude-after-remap --temp-directory coverage/e2e-client/tmp

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ const VITEST_CONFIG: InlineConfig = {
   threads: false,
   coverage: {
     reporter: ["text", "html"],
+    reportsDirectory: "coverage/unit",
   },
 };
 


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/58

## example output

- https://github.com/hi-ogawa/ytsub-v3/runs/6147514765?check_suite_focus=true#step:12:10
- https://htmlpreview.github.io/?https://raw.githubusercontent.com/hi-ogawa/ytsub-v3/__coverage__/a4b381b8e5a1ea5247479b2468896b1ec3254564/all/index.html

## todo

- [ ] ~e2e-server looks wrong?~ (will work on later)

- [x] what kind of coverage json files vitest/c8 generate?
<details>

<summary>somehow vitest's "url" is already resolved to the original source</summary>

```json
    {
      "scriptId": "1035",
      "url": "file:///home/hiroshi/code/personal/ytsub-v3/app/utils/auth.ts",
      "functions": [
        {
          "functionName": "",
          "ranges": [
            {
              "startOffset": 0,
              "endOffset": 8388,
              "count": 1
            }
          ],
          "isBlockCoverage": true
        },
        {
          "functionName": "",
          "ranges": [
            {
              "startOffset": 13,
              "endOffset": 8388,
              "count": 1
            }
          ],
          "isBlockCoverage": true
        },
        {
          "functionName": "get",
          "ranges": [
            {
              "startOffset": 930,
              "endOffset": 965,
              "count": 0
            }
          ],
          "isBlockCoverage": false
        },
```

</details>