### PR TITLE
feat: emphasize bookmark text by underline

### DIFF
--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -617,7 +617,7 @@ function HighlightText({
   return (
     <>
       {t1}
-      <span className="bg-sky-200/[0.7]">{t2}</span>
+      <span className="underline">{t2}</span>
       {t3}
     </>
   );


### PR DESCRIPTION
- relates to https://github.com/hi-ogawa/ytsub-v3/pull/103

Now that I think about it, underline is definitely universally simply clear.

## screenshots

![image](https://user-images.githubusercontent.com/4232207/167288567-35fa86f0-8edf-4101-a3a7-96383b34a0c7.png)
