### PR TITLE
feat(ui): underline current queueType on practice

### DIFF
--- a/app/routes/decks/$id/practice.tsx
+++ b/app/routes/decks/$id/practice.tsx
@@ -97,7 +97,6 @@ export default function DefaultComponent() {
   const { deck, statistics, data }: LoaderData = useDeserialize(
     useLoaderData()
   );
-  !data.finished && data.practiceEntry.queueType === "NEW";
 
   return (
     <div className="h-full w-full flex justify-center">

--- a/app/routes/decks/$id/practice.tsx
+++ b/app/routes/decks/$id/practice.tsx
@@ -97,6 +97,7 @@ export default function DefaultComponent() {
   const { deck, statistics, data }: LoaderData = useDeserialize(
     useLoaderData()
   );
+  !data.finished && data.practiceEntry.queueType === "NEW";
 
   return (
     <div className="h-full w-full flex justify-center">
@@ -108,15 +109,33 @@ export default function DefaultComponent() {
             </div>
             <div className="grow flex px-4">
               <div className="grow" />
-              <div className="flex-none text-blue-500">
+              <div
+                className={`flex-none text-blue-500 ${
+                  !data.finished &&
+                  data.practiceEntry.queueType === "NEW" &&
+                  "underline"
+                }`}
+              >
                 {statistics.NEW.daily} / {statistics.NEW.total}
               </div>
               <div className="grow text-center text-gray-400">-</div>
-              <div className="flex-none text-red-500">
+              <div
+                className={`flex-none text-red-500 ${
+                  !data.finished &&
+                  data.practiceEntry.queueType === "LEARN" &&
+                  "underline"
+                }`}
+              >
                 {statistics.LEARN.daily} / {statistics.LEARN.total}
               </div>
               <div className="grow text-center text-gray-400">-</div>
-              <div className="flex-none text-green-500">
+              <div
+                className={`flex-none text-green-500 ${
+                  !data.finished &&
+                  data.practiceEntry.queueType === "REVIEW" &&
+                  "underline"
+                }`}
+              >
                 {statistics.REVIEW.daily} / {statistics.REVIEW.total}
               </div>
               <div className="grow" />


### PR DESCRIPTION
The underline would help since it's less obvious during random order mode.

## screenshots

![image](https://user-images.githubusercontent.com/4232207/167303898-4c7bf312-2e5c-4c81-82ea-6507875504d1.png)
