### PR TITLE
chore: add "console" script

### DIFF
--- a/app/misc/console.ts
+++ b/app/misc/console.ts
@@ -1,0 +1,7 @@
+import { client } from "../db/client.server";
+import { Q } from "../db/models";
+
+Object.assign(global, {
+  client,
+  Q,
+});

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "netlify:build:deploy:production": "npm run netlify:build && netlify deploy --prod",
     "cli": "node --require esbuild-register app/misc/cli.ts",
     "cli:production": "eval $(bash .env.production.sh) && node --require esbuild-register app/misc/cli.ts",
+    "console": "node --experimental-repl-await -r esbuild-register -r ./app/misc/console.ts",
+    "console:staging": "eval $(bash .env.staging.sh) && npm run console",
     "knex:staging": "eval $(bash .env.staging.sh) && knex",
     "knex:production": "eval $(bash .env.production.sh) && knex",
     "diff": "git diff --name-only HEAD && git ls-files --others --exclude-standard",


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/114

## example

```sh
$ npm run console
> await Q.captionEntries().select("id", "text1", "text2", { x: client.raw("CAST(CONV(SUBSTRING(HEX(UNHEX(SHA1(id)) ^ UNHEX(SHA1(updatedAt))), 1, 8), 16, 10) as SIGNED)") }).orderBy("x").limit(3)
[
  {
    id: 254,
    text1: 'désinfecter les mains, pour me laver les mains.',
    text2: 'For example, when I get out of the subway.',
    x: 1927590
  },
  {
    id: 345,
    text1: "déjà on peut dire que ça ressemble à un immeuble parisien ouais c'est dans des quartiers",
    text2: "first of all, we can say that it looks like a Parisian building yeah it's in chic neighborhoods",
    x: 2401345
  },
  {
    id: 3991,
    text1: "Ça y est, c'est la fin. Je viens de finir ma  dernière journée de ski. Je viens d'aller rendre",
    text2: "That's it, it's the end. I just finished my last day of skiing. I just went to return",
    x: 5089629
  }
]
```