### PR TITLE
fix: random mode practice order query

### DIFF
--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -116,7 +116,7 @@ export class PracticeSystem {
         .where("practiceEntries.scheduledAt", "<=", now)
         .orderByRaw(
           // pseudo random with "id" and "updatedAt" as seeds
-          "CONV(SUBSTRING(HEX(UNHEX(SHA1(id)) ^ UNHEX(SHA1(updatedAt))), 1, 8), 16, 10)"
+          "CAST(CONV(SUBSTRING(HEX(UNHEX(SHA1(id)) ^ UNHEX(SHA1(updatedAt))), 1, 8), 16, 10) as UNSIGNED)"
         )
         .first();
       return result;


### PR DESCRIPTION
When using only "local" values as seed, it's possible to get stack at the last order.
Combining globally incrementally changing `MAX(updatedAt)` as another seed, this will allow shuffling the order in every practice loop.

## todo

- [x] test new query on vitess

```
$ DEBUG=knex:query npm run console:staging
> await Q.practiceEntries().select("practiceEntries.*", { __seed__: client.raw("(SELECT updatedAt FROM practiceEntries where deckId = 1 ORDER BY updatedAt DESC LIMIT 1)") }).orderByRaw("CAST(CONV(SUBSTRING(HEX(UNHEX(SHA1(SHA1(__seed__))) ^ UNHEX(SHA1(id)) ^ UNHEX(SHA1(updatedAt))), 1, 8), 16, 10) as UNSIGNED)").first();
  knex:query select `practiceEntries`.*, (SELECT updatedAt FROM practiceEntries where deckId = 1 ORDER BY updatedAt DESC LIMIT 1) as `__seed__` from `practiceEntries` order by CAST(CONV(SUBSTRING(HEX(UNHEX(SHA1(SHA1(__seed__))) ^ UNHEX(SHA1(id)) ^ UNHEX(SHA1(updatedAt))), 1, 8), 16, 10) as UNSIGNED) limit ? undefined +59s
{
  id: 37,
  queueType: 'LEARN',
  easeFactor: 1,
  scheduledAt: 2022-05-08T04:18:41.000Z,
  createdAt: 2022-05-03T07:51:07.000Z,
  updatedAt: 2022-05-08T04:13:41.000Z,
  deckId: 1,
  bookmarkEntryId: 390,
  __seed__: 2022-05-08T15:27:13.000Z
}
```