### PR TITLE
fix: fix `useRafLoop`

### DIFF
--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -314,8 +314,6 @@ export function MiniPlayer({
     onLoad: setPlayer,
   });
 
-  // TODO: toggling `isRepeating` might be broken (on mobile).
-  //       it seems `useRafLoop` is not unregistering the old callback properly.
   useRafLoop(
     React.useCallback(() => {
       if (!player) return;

--- a/app/utils/hooks.ts
+++ b/app/utils/hooks.ts
@@ -7,8 +7,9 @@ export function useRafLoop(callback: () => void): void {
   React.useEffect(() => {
     let id: number | undefined;
     function loop() {
-      callback();
+      // NOTE: queue next loop before `callback` since `callback` can cause "effect cleanup"
       id = requestAnimationFrame(loop);
+      callback();
     }
     loop();
     return () => {


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/142

It's still not that obvious how react schedules effect setup/cleanup, but it seems this ordering is more robust in general.
See above issue's comment https://github.com/hi-ogawa/ytsub-v3/issues/142#issuecomment-1140242168 for how this is debugged.