### PR TITLE
fix: fix query in history page

### DIFF
--- a/app/__e2e__/decks.test.ts
+++ b/app/__e2e__/decks.test.ts
@@ -73,11 +73,35 @@ test.describe("decks", () => {
     await page.locator("data-test=pagination >> a >> nth=2").click();
     await expect(page).toHaveURL(/\/decks\/\d+\?perPage=20&page=2$/);
 
-    // navigate to "/decks/$id/history"
+    // navigate to "/decks/$id/history-graph"
     await page.locator("data-test=deck-menu-popover-reference").click();
     await page
       .locator("data-test=deck-menu-popover-floating >> text=History")
       .click();
     await expect(page).toHaveURL(/\/decks\/\d+\/history-graph$/);
+  });
+
+  test("show-deck-empty", async ({ page }) => {
+    await signin(page);
+    await page.goto("/decks");
+
+    // navigate to "test-empty"
+    await page.locator("text=test-empty").click();
+    await expect(page).toHaveURL(/\/decks\/\d+$/);
+
+    // navigate to "/decks/$id/history-graph"
+    await page.locator("data-test=deck-menu-popover-reference").click();
+    await page
+      .locator("data-test=deck-menu-popover-floating >> text=History")
+      .click();
+    await expect(page).toHaveURL(/\/decks\/\d+\/history-graph$/);
+
+    // navigate to "/decks/$id/history"
+    await page.locator("data-test=deck-menu-history-popover-reference").click();
+    await page
+      .locator("data-test=deck-menu-history-popover-floating >> text=List")
+      .click();
+    await expect(page).toHaveURL(/\/decks\/\d+\/history$/);
+    await expect(page.locator(`data-test=main >> "Empty"`)).toBeVisible();
   });
 });

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -148,7 +148,7 @@ function Root() {
             user={data.currentUser}
             menu={navBarMenu?.()}
           />
-          <div className="flex-[1_0_0] flex flex-col">
+          <div className="flex-[1_0_0] flex flex-col" data-test="main">
             <div className="w-full flex-[1_0_0] h-full overflow-y-auto">
               <Outlet />
             </div>

--- a/app/routes/decks/$id/history-graph.tsx
+++ b/app/routes/decks/$id/history-graph.tsx
@@ -220,7 +220,7 @@ export function NavBarMenuComponent() {
           reference={({ props }) => (
             <button
               className="btn btn-sm btn-ghost"
-              data-test="deck-menu-popover-reference"
+              data-test="deck-menu-history-popover-reference"
               {...props}
             >
               <MoreVertical />
@@ -239,7 +239,7 @@ export function NavBarMenuComponent() {
             >
               <ul
                 className="menu menu-compact rounded p-3 shadow w-48 bg-base-100 text-base-content text-sm"
-                data-test="deck-menu-popover-floating"
+                data-test="deck-menu-history-popover-floating"
               >
                 <li>
                   <Link

--- a/app/routes/decks/$id/history.tsx
+++ b/app/routes/decks/$id/history.tsx
@@ -72,6 +72,7 @@ export const loader = makeLoader(Controller, async function () {
       "bookmarkEntries.id",
       "practiceEntries.bookmarkEntryId"
     )
+    .where("practiceActions.deckId", deck.id)
     .orderBy("practiceActions.createdAt", "desc");
 
   if (parsed.data.practiceEntryId) {

--- a/app/routes/decks/$id/practice.tsx
+++ b/app/routes/decks/$id/practice.tsx
@@ -256,7 +256,7 @@ function NavBarMenuComponent() {
           reference={({ props }) => (
             <button
               className="btn btn-sm btn-ghost"
-              data-test="deck-menu-popover-reference"
+              data-test="deck-menu-practice-popover-reference"
               {...props}
             >
               <MoreVertical />
@@ -275,7 +275,7 @@ function NavBarMenuComponent() {
             >
               <ul
                 className="menu menu-compact rounded p-3 shadow w-48 bg-base-100 text-base-content text-sm"
-                data-test="deck-menu-popover-floating"
+                data-test="deck-menu-practice-popover-floating"
               >
                 <li>
                   <Link


### PR DESCRIPTION
Fixed filter `where("practiceActions.deckId", deck.id)` in `/decks/$id/history` page.