### PR TITLE
chore: allow viewport scale

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -62,8 +62,7 @@ export const meta: MetaFunction = () => {
   return {
     title:
       (publicConfig.VERCEL_ENV === "preview" ? "[PREVIEW] " : "") + "ytsub-v3",
-    viewport:
-      "width=device-width, height=device-height, initial-scale=1, maximum-scale=1, user-scalable=no",
+    viewport: "width=device-width, height=device-height, initial-scale=1",
   };
 };
 


### PR DESCRIPTION
I had a habit of copy-pasting `initial-scale=1, maximum-scale=1, user-scalable=no` from somewhere, but recently I started to remove `maximum-scale=1, user-scalable=no`.