### PR TITLE
ci: use release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ on:
         default: production
 jobs:
   release:
+    environment:
+      name: release
     runs-on: ubuntu-22.04
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/ytsub-v3/pull/205

Replaced "action secrets" https://github.com/hi-ogawa/ytsub-v3/settings/secrets/actions with "environment secrets" https://github.com/hi-ogawa/ytsub-v3/settings/environments/934681287/edit


Using "environment" gives nicer UI so why not.

![image](https://user-images.githubusercontent.com/4232207/227427519-7a86bf24-6eec-4bc7-a72d-afb267b3013a.png)
