### PR TITLE
feat: add typing practice link

### DIFF
--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -335,6 +335,7 @@ export function MiniPlayer({
         videoId={video.id}
         border={false}
         highlight={highlight}
+        showTypingPractice
       />
       <div className="relative w-full">
         <div className="relative pt-[56.2%]">

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -335,7 +335,6 @@ export function MiniPlayer({
         videoId={video.id}
         border={false}
         highlight={highlight}
-        showTypingPractice
       />
       <div className="relative w-full">
         <div className="relative pt-[56.2%]">

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -539,7 +539,6 @@ export function CaptionEntryComponent({
   videoId,
   border = true,
   highlight,
-  showTypingPractice,
   // virtualized list
   virtualizer,
   virtualItem,
@@ -555,7 +554,6 @@ export function CaptionEntryComponent({
   videoId?: number;
   border?: boolean;
   highlight?: { side: number; offset: number; length: number };
-  showTypingPractice?: boolean;
   // virtualized list
   virtualizer?: Virtualizer<HTMLDivElement, Element>;
   virtualItem?: VirtualItem;
@@ -595,14 +593,13 @@ export function CaptionEntryComponent({
             data-test="caption-entry-component__video-link"
           />
         )}
-        {showTypingPractice && (
-          <a
-            // prettier-ignore
-            href={`https://10fastfingers.com/widget/typingtest?dur=600&rand=0&words=${encodeURIComponent(entry.text1)}`}
-            className="antd-btn antd-btn-ghost i-ri-keyboard-box-line w-4 h-4"
-            target="_blank"
-          />
-        )}
+        <a
+          // prettier-ignore
+          href={`https://10fastfingers.com/widget/typingtest?dur=600&rand=0&words=${encodeURIComponent(entry.text1)}`}
+          // use "media-mouse" as keyboard detection heuristics https://github.com/w3c/csswg-drafts/issues/3871
+          className="antd-btn antd-btn-ghost i-ri-keyboard-line w-4 h-4 hidden media-mouse:inline"
+          target="_blank"
+        />
         <button
           className={cls(
             `antd-btn antd-btn-ghost i-ri-repeat-line w-3 h-3`,

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -539,6 +539,7 @@ export function CaptionEntryComponent({
   videoId,
   border = true,
   highlight,
+  showTypingPractice,
   // virtualized list
   virtualizer,
   virtualItem,
@@ -554,6 +555,7 @@ export function CaptionEntryComponent({
   videoId?: number;
   border?: boolean;
   highlight?: { side: number; offset: number; length: number };
+  showTypingPractice?: boolean;
   // virtualized list
   virtualizer?: Virtualizer<HTMLDivElement, Element>;
   virtualItem?: VirtualItem;
@@ -591,6 +593,14 @@ export function CaptionEntryComponent({
             to={R["/videos/$id"](videoId) + `?index=${entry.index}`}
             className="antd-btn antd-btn-ghost i-ri-vidicon-line w-4 h-4"
             data-test="caption-entry-component__video-link"
+          />
+        )}
+        {showTypingPractice && (
+          <a
+            // prettier-ignore
+            href={`https://10fastfingers.com/widget/typingtest?dur=600&rand=0&words=${encodeURIComponent(entry.text1)}`}
+            className="antd-btn antd-btn-ghost i-ri-keyboard-box-line w-4 h-4"
+            target="_blank"
           />
         )}
         <button


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/217

This adds a small link using caption text, for example:

- https://10fastfingers.com/widget/typingtest?dur=600&rand=0&words=%EC%95%84%EB%B9%A0%ED%95%9C%ED%85%8C%20%EB%8B%A4%20%EC%9D%B4%EB%A5%BC%20%EA%B1%B0%EC%95%BC

## screenshots

<details>

![image](https://user-images.githubusercontent.com/4232207/229016599-137caef7-43d8-456b-ae13-a883e879898d.png)

</details>