### PR TITLE
refactor: replace `useFetcher` with react-query

### DIFF
--- a/app/db/models.ts
+++ b/app/db/models.ts
@@ -17,7 +17,12 @@ export type PracticeActionTable = TT["practiceActions"];
 // cf. Anki's practice system
 // - https://docs.ankiweb.net/studying.html
 // - https://docs.ankiweb.net/deck-options.html
-const Z_PRACTICE_ACTION_TYPES = z.enum(["AGAIN", "HARD", "GOOD", "EASY"]);
+export const Z_PRACTICE_ACTION_TYPES = z.enum([
+  "AGAIN",
+  "HARD",
+  "GOOD",
+  "EASY",
+]);
 const Z_PRACTICE_QUEUE_TYPES = z.enum(["NEW", "LEARN", "REVIEW"]);
 export const PRACTICE_ACTION_TYPES = Z_PRACTICE_ACTION_TYPES.options;
 export const PRACTICE_QUEUE_TYPES = Z_PRACTICE_QUEUE_TYPES.options;

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -379,7 +379,9 @@ cli
         .transacting(trx)
         .select({
           id: "videos.id",
-          bookmarkEntriesCount: client.raw("COUNT(bookmarkEntries.id)"),
+          bookmarkEntriesCount: client.raw(
+            "COALESCE(COUNT(bookmarkEntries.id), 0)"
+          ),
           updatedAt: "videos.updatedAt", // prevent changing `updatedAt` timestamp for the migration
           videoId: client.raw("'dummy'"),
           language1_id: client.raw("'dummy'"),
@@ -389,8 +391,7 @@ cli
           channelId: client.raw("'dummy'"),
         })
         .leftJoin("bookmarkEntries", "bookmarkEntries.videoId", "videos.id")
-        .groupBy("videos.id")
-        .having("bookmarkEntriesCount", ">", 0);
+        .groupBy("videos.id");
       await Q.videos()
         .transacting(trx)
         .insert(rows)
@@ -407,7 +408,9 @@ cli
         .transacting(trx)
         .select({
           id: "practiceEntries.id",
-          practiceActionsCount: client.raw("COUNT(practiceActions.id)"),
+          practiceActionsCount: client.raw(
+            "COALESCE(COUNT(practiceActions.id), 0)"
+          ),
           updatedAt: "practiceEntries.updatedAt", // prevent changing `updatedAt` timestamp for the migration
           queueType: client.raw("'dummy'"),
           easeFactor: 0,
@@ -420,8 +423,7 @@ cli
           "practiceActions.practiceEntryId",
           "practiceEntries.id"
         )
-        .groupBy("practiceEntries.id")
-        .having("practiceActionsCount", ">", 0);
+        .groupBy("practiceEntries.id");
       await Q.practiceEntries()
         .transacting(trx)
         .insert(rows)

--- a/app/misc/routes.ts
+++ b/app/misc/routes.ts
@@ -32,7 +32,3 @@ export const R = {
   "/decks/$id/new-practice-action": (id: number) => `/decks/${id}/new-practice-action`,
   "/decks/$id/export": (id: number) => `/decks/${id}/export`,
 };
-
-export const R_RE = {
-  "/decks/$id/practice": /\/decks\/\d+\/practice/,
-};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,7 +9,6 @@ import {
   NavLink,
   Outlet,
   Scripts,
-  ShouldReloadFunction,
   useMatches,
 } from "@remix-run/react";
 import type { LinksFunction, MetaFunction } from "@remix-run/server-runtime";
@@ -23,7 +22,7 @@ import { PopoverSimple } from "./components/popover";
 import { ThemeSelect } from "./components/theme-select";
 import { TopProgressBarRemix } from "./components/top-progress-bar";
 import type { UserTable } from "./db/models";
-import { R, R_RE } from "./misc/routes";
+import { R } from "./misc/routes";
 import { HideRecaptchaBadge } from "./routes/users/register";
 import { publicConfig } from "./utils/config";
 import { ConfigPlaceholder } from "./utils/config-placeholder";
@@ -66,25 +65,6 @@ export const loader = makeLoader(Controller, async function () {
   };
   return this.serialize(data);
 });
-
-export const unstable_shouldReload: ShouldReloadFunction = ({
-  submission,
-  url,
-  prevUrl,
-}) => {
-  if (submission?.action === R["/bookmarks/new"]) {
-    return false;
-  }
-  // skip reload during "practice" loop
-  if (
-    url.pathname === prevUrl.pathname &&
-    url.pathname.match(R_RE["/decks/$id/practice"])
-  ) {
-    return false;
-  }
-  // TODO: rest should fallback to default behavior
-  return true;
-};
 
 //
 // component

--- a/app/routes/__tests__/bookmarks-new.test.ts
+++ b/app/routes/__tests__/bookmarks-new.test.ts
@@ -30,16 +30,20 @@ describe("bookmarks/new.action", () => {
       .innerJoin(T.videos, E.eq(T.videos.id, T.bookmarkEntries.videoId))
       .where(E.eq(T.videos.id, hook.video.id));
     expect(
-      rows.map((row) =>
-        objectPick(row.bookmarkEntries, ["text", "side", "offset"])
-      )
+      rows.map((row) => [
+        row.videos.bookmarkEntriesCount,
+        objectPick(row.bookmarkEntries, ["text", "side", "offset"]),
+      ])
     ).toMatchInlineSnapshot(`
       [
-        {
-          "offset": 8,
-          "side": 0,
-          "text": "Bonjour à tous",
-        },
+        [
+          1,
+          {
+            "offset": 8,
+            "side": 0,
+            "text": "Bonjour à tous",
+          },
+        ],
       ]
     `);
   });

--- a/app/routes/__tests__/helper.ts
+++ b/app/routes/__tests__/helper.ts
@@ -114,13 +114,21 @@ const NEW_VIDEOS: NewVideo[] = [
   },
 ];
 
-export function useVideo(type: 0 | 1 | 2 = 2) {
-  const newVideo = NEW_VIDEOS[type];
+export function useVideo(
+  args?: { videoFixture?: 0 | 1 | 2 },
+  userHook?: ReturnType<typeof useUser>
+) {
+  const newVideo = NEW_VIDEOS[args?.videoFixture ?? 2];
   let result: { video: VideoTable; captionEntries: CaptionEntryTable[] };
 
   beforeAll(async () => {
+    await userHook?.isReady;
     const data = await fetchCaptionEntries(newVideo);
-    const videoId = await insertVideoAndCaptionEntries(newVideo, data);
+    const videoId = await insertVideoAndCaptionEntries(
+      newVideo,
+      data,
+      userHook?.data.id
+    );
     const resultOption = await getVideoAndCaptionEntries(videoId);
     tinyassert(resultOption);
     result = resultOption;
@@ -140,45 +148,22 @@ export function useVideo(type: 0 | 1 | 2 = 2) {
   };
 }
 
-// TODO: jest/vitest doesn't serialize `before` hooks, so we cannot simply combine `useUser` and `useVideo`
 export function useUserVideo(
-  type: 0 | 1 | 2 = 2,
-  ...args: Parameters<typeof useUserImpl>
+  args: Parameters<typeof useUser>[0] & { videoFixture?: 0 | 1 | 2 }
 ) {
-  const { before, after } = useUserImpl(...args);
-
-  let user: UserTable;
-  let cookie: string;
-  let video: VideoTable;
-  let captionEntries: CaptionEntryTable[];
-  const newVideo = NEW_VIDEOS[type];
-
-  beforeAll(async () => {
-    user = await before();
-    cookie = await createUserCookie(user);
-
-    const data = await fetchCaptionEntries(newVideo);
-    const videoId = await insertVideoAndCaptionEntries(newVideo, data, user.id);
-    const result = await getVideoAndCaptionEntries(videoId);
-    tinyassert(result);
-    video = result.video;
-    captionEntries = result.captionEntries;
-  });
-
-  afterAll(async () => {
-    await after();
-    await db.delete(T.videos).where(E.eq(T.videos.id, video.id));
-  });
-
-  function signin(request: Request): Request {
-    request.headers.set("cookie", cookie);
-    return request;
-  }
+  const userHook = useUser(args);
+  const videoHook = useVideo(args, userHook);
 
   return {
-    user: () => user,
-    video: () => video,
-    captionEntries: () => captionEntries,
-    signin,
+    signin: userHook.signin,
+    get user() {
+      return userHook.data;
+    },
+    get video() {
+      return videoHook.video;
+    },
+    get captionEntries() {
+      return videoHook.captionEntries;
+    },
   };
 }

--- a/app/routes/__tests__/helper.ts
+++ b/app/routes/__tests__/helper.ts
@@ -114,15 +114,13 @@ const NEW_VIDEOS: NewVideo[] = [
   },
 ];
 
-// TODO: simplify like useUser
-export function useVideo(type: 0 | 1 | 2 = 2, userId?: () => number) {
+export function useVideo(type: 0 | 1 | 2 = 2) {
   const newVideo = NEW_VIDEOS[type];
   let result: { video: VideoTable; captionEntries: CaptionEntryTable[] };
 
   beforeAll(async () => {
-    const id = userId?.();
     const data = await fetchCaptionEntries(newVideo);
-    const videoId = await insertVideoAndCaptionEntries(newVideo, data, id);
+    const videoId = await insertVideoAndCaptionEntries(newVideo, data);
     const resultOption = await getVideoAndCaptionEntries(videoId);
     tinyassert(resultOption);
     result = resultOption;
@@ -133,8 +131,12 @@ export function useVideo(type: 0 | 1 | 2 = 2, userId?: () => number) {
   });
 
   return {
-    video: () => result.video,
-    captionEntries: () => result.captionEntries,
+    get video() {
+      return result.video;
+    },
+    get captionEntries() {
+      return result.captionEntries;
+    },
   };
 }
 

--- a/app/routes/__tests__/helper.ts
+++ b/app/routes/__tests__/helper.ts
@@ -22,6 +22,7 @@ export function testLoader(
     method,
     query,
     form,
+    json,
     params = {},
     transform,
   }: {
@@ -29,6 +30,7 @@ export function testLoader(
     query?: any;
     form?: any;
     params?: Record<string, string>;
+    json?: unknown;
     transform?: (request: Request) => Request;
   } = {}
 ) {
@@ -37,6 +39,12 @@ export function testLoader(
     url += "/?" + toQuery(query);
   }
   let request = new Request(url, { method: method ?? "GET" });
+  if (json) {
+    request = new Request(url, {
+      method: method ?? "POST",
+      body: JSON.stringify(json),
+    });
+  }
   if (form) {
     request = new Request(url, {
       method: method ?? "POST",
@@ -106,6 +114,7 @@ const NEW_VIDEOS: NewVideo[] = [
   },
 ];
 
+// TODO: simplify like useUser
 export function useVideo(type: 0 | 1 | 2 = 2, userId?: () => number) {
   const newVideo = NEW_VIDEOS[type];
   let result: { video: VideoTable; captionEntries: CaptionEntryTable[] };

--- a/app/routes/__tests__/videos-id.test.ts
+++ b/app/routes/__tests__/videos-id.test.ts
@@ -64,21 +64,16 @@ describe("videos/id.action", () => {
       id: video().id,
       userId: user().id,
     };
-    expect(Q.videos().where(where).first()).resolves.toBeDefined();
+    expect((await Q.videos().where(where)).length).toMatchInlineSnapshot("1");
 
     const res = await testLoader(action, {
       method: "DELETE",
       params: { id: String(video().id) },
       transform: signin,
     });
-    const resJson = await res.json();
-    expect(resJson).toMatchInlineSnapshot(`
-      {
-        "success": true,
-        "type": "DELETE /videos/\$id",
-      }
-    `);
+    tinyassert(res instanceof Response);
+    tinyassert(res.ok);
 
-    expect(Q.videos().where(where).first()).resolves.toBe(undefined);
+    expect((await Q.videos().where(where)).length).toMatchInlineSnapshot("0");
   });
 });

--- a/app/routes/__tests__/videos-id.test.ts
+++ b/app/routes/__tests__/videos-id.test.ts
@@ -73,8 +73,8 @@ describe("videos/id.action", () => {
     await expect(getVideos()).resolves.toHaveLength(1);
 
     const res = await testLoader(action, {
-      method: "DELETE",
       params: { id: String(hook.video.id) },
+      json: { destroy: true },
       transform: hook.signin,
     });
     tinyassert(res instanceof Response);

--- a/app/routes/__tests__/videos-id.test.ts
+++ b/app/routes/__tests__/videos-id.test.ts
@@ -1,5 +1,4 @@
-import { tinyassert } from "@hiogawa/utils";
-import { omit } from "lodash";
+import { objectOmit, objectPick, tinyassert } from "@hiogawa/utils";
 import { describe, expect, it } from "vitest";
 import { CaptionEntryTable, Q, VideoTable } from "../../db/models";
 import { deserialize } from "../../utils/controller-utils";
@@ -8,24 +7,30 @@ import { useUserVideo, useVideo } from "./helper";
 import { testLoader } from "./helper";
 
 describe("videos/id.loader", () => {
-  const { video } = useVideo();
+  const videoHook = useVideo();
 
   it("basic", async () => {
     const res = await testLoader(loader, {
-      params: { id: String(video().id) },
+      params: { id: String(videoHook.video.id) },
     });
     tinyassert(res instanceof Response);
+    tinyassert(res.ok);
+
     const resJson: { video: VideoTable; captionEntries: CaptionEntryTable[] } =
       deserialize(await res.json());
-    expect(resJson.video.videoId).toBe("EnPYXckiUVg");
-    expect(resJson.video.title).toMatchInlineSnapshot(
-      '"Are French People Really That Mean?! // French Girls React to Emily In Paris (in FR w/ FR & EN subs)"'
-    );
-    expect(resJson.captionEntries.length).toMatchInlineSnapshot("183");
+
+    expect(objectPick(resJson.video, ["videoId", "title"]))
+      .toMatchInlineSnapshot(`
+      {
+        "title": "Are French People Really That Mean?! // French Girls React to Emily In Paris (in FR w/ FR & EN subs)",
+        "videoId": "EnPYXckiUVg",
+      }
+    `);
+
     expect(
       resJson.captionEntries
         .slice(0, 3)
-        .map((e) => omit(e, ["id", "videoId", "createdAt", "updatedAt"]))
+        .map((e) => objectOmit(e, ["id", "videoId", "createdAt", "updatedAt"]))
     ).toMatchInlineSnapshot(`
       [
         {

--- a/app/routes/bookmarks/new.tsx
+++ b/app/routes/bookmarks/new.tsx
@@ -1,4 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
+import { sql } from "drizzle-orm";
 import { z } from "zod";
 import { E, T, db, findOne } from "../../db/drizzle-client.server";
 import { R } from "../../misc/routes";
@@ -46,7 +47,7 @@ export const action = makeLoader(Controller, async function () {
   });
   await db
     .update(T.videos)
-    .set({ bookmarkEntriesCount: found.videos.bookmarkEntriesCount + 1 })
+    .set({ bookmarkEntriesCount: sql`${T.videos.bookmarkEntriesCount} + 1` })
     .where(E.eq(T.videos.id, req.videoId));
   return null;
 });

--- a/app/routes/bookmarks/new.tsx
+++ b/app/routes/bookmarks/new.tsx
@@ -37,7 +37,7 @@ export const action = makeLoader(Controller, async function () {
         )
       )
   );
-  tinyassert(found);
+  tinyassert(found, "not found");
 
   // insert with counter cache increment
   await db.insert(T.bookmarkEntries).values({

--- a/app/routes/bookmarks/new.tsx
+++ b/app/routes/bookmarks/new.tsx
@@ -46,7 +46,8 @@ export const action = makeLoader(Controller, async function () {
   });
   await db
     .update(T.videos)
-    .set({ bookmarkEntriesCount: found.videos.bookmarkEntriesCount + 1 });
+    .set({ bookmarkEntriesCount: found.videos.bookmarkEntriesCount + 1 })
+    .where(E.eq(T.videos.id, req.videoId));
   return null;
 });
 

--- a/app/routes/bookmarks/new.tsx
+++ b/app/routes/bookmarks/new.tsx
@@ -47,6 +47,7 @@ export const action = makeLoader(Controller, async function () {
   await db
     .update(T.videos)
     .set({ bookmarkEntriesCount: found.videos.bookmarkEntriesCount + 1 });
+  return null;
 });
 
 // client query

--- a/app/routes/decks/$id/new-practice-action.tsx
+++ b/app/routes/decks/$id/new-practice-action.tsx
@@ -36,6 +36,7 @@ export const action = makeLoader(Controller, async function () {
 
   const system = new PracticeSystem(user, deck);
   await system.createPracticeAction(practiceEntry, actionType, new Date());
+  return null;
 });
 
 // client query

--- a/app/routes/decks/$id/new-practice-action.tsx
+++ b/app/routes/decks/$id/new-practice-action.tsx
@@ -40,10 +40,11 @@ export const action = makeLoader(Controller, async function () {
 
 // client query
 export function createNewPracticeActionMutation() {
+  const url = R["/decks/$id/new-practice-action"];
   return {
-    mutationKey: ["/decks/$id/new-practice-action"],
+    mutationKey: [String(url)],
     mutationFn: async (req: NewPracticeActionRequest & { deckId: number }) => {
-      const res = await fetch(R["/decks/$id/new-practice-action"](req.deckId), {
+      const res = await fetch(url(req.deckId), {
         method: "POST",
         body: JSON.stringify(req),
       });

--- a/app/routes/decks/$id/new-practice-action.tsx
+++ b/app/routes/decks/$id/new-practice-action.tsx
@@ -1,36 +1,53 @@
 import { requireUserAndDeck } from ".";
 import { tinyassert } from "@hiogawa/utils";
-import { redirect } from "@remix-run/server-runtime";
 import { z } from "zod";
-import { PRACTICE_ACTION_TYPES, Q } from "../../../db/models";
+import { E, T, db, findOne } from "../../../db/drizzle-client.server";
+import { Z_PRACTICE_ACTION_TYPES } from "../../../db/models";
 import { R } from "../../../misc/routes";
 import { Controller, makeLoader } from "../../../utils/controller-utils";
 import { PracticeSystem } from "../../../utils/practice-system";
+
+// TODO: move to /decks/new-practice-action.tsx ?
 
 //
 // action
 //
 
 const ACTION_REQUEST_SCHEMA = z.object({
-  practiceEntryId: z.coerce.number().int(),
-  actionType: z.enum(PRACTICE_ACTION_TYPES),
-  now: z.coerce.date(),
+  practiceEntryId: z.number().int(),
+  actionType: Z_PRACTICE_ACTION_TYPES,
 });
 
-export type NewPracticeActionRequest = z.infer<typeof ACTION_REQUEST_SCHEMA>;
+type NewPracticeActionRequest = z.infer<typeof ACTION_REQUEST_SCHEMA>;
 
 export const action = makeLoader(Controller, async function () {
   const [user, deck] = await requireUserAndDeck.apply(this);
-  const parsed = ACTION_REQUEST_SCHEMA.safeParse(await this.form());
-  tinyassert(parsed.success);
+  const { practiceEntryId, actionType } = ACTION_REQUEST_SCHEMA.parse(
+    await this.request.json()
+  );
 
-  const { practiceEntryId, actionType, now } = parsed.data;
-  const practiceEntry = await Q.practiceEntries()
-    .where({ id: practiceEntryId })
-    .first();
+  const practiceEntry = await findOne(
+    db
+      .select()
+      .from(T.practiceEntries)
+      .where(E.eq(T.practiceEntries.id, practiceEntryId))
+  );
   tinyassert(practiceEntry);
 
   const system = new PracticeSystem(user, deck);
-  await system.createPracticeAction(practiceEntry, actionType, now);
-  return redirect(R["/decks/$id/practice"](deck.id));
+  await system.createPracticeAction(practiceEntry, actionType, new Date());
 });
+
+// client query
+export function createNewPracticeActionMutation() {
+  return {
+    mutationKey: ["/decks/$id/new-practice-action"],
+    mutationFn: async (req: NewPracticeActionRequest & { deckId: number }) => {
+      const res = await fetch(R["/decks/$id/new-practice-action"](req.deckId), {
+        method: "POST",
+        body: JSON.stringify(req),
+      });
+      tinyassert(res.ok);
+    },
+  };
+}

--- a/app/routes/decks/$id/new-practice-entry.tsx
+++ b/app/routes/decks/$id/new-practice-entry.tsx
@@ -6,6 +6,8 @@ import { R } from "../../../misc/routes";
 import { Controller, makeLoader } from "../../../utils/controller-utils";
 import { PracticeSystem } from "../../../utils/practice-system";
 
+// TODO: move to /decks/new-practice-entry.tsx ?
+
 //
 // action
 //

--- a/app/routes/decks/index-detail.tsx
+++ b/app/routes/decks/index-detail.tsx
@@ -63,6 +63,7 @@ export const action = makeLoader(Controller, async function () {
   return this.serialize(loaderData);
 });
 
+// client query
 export function createDecksIndexDetailQuery(req: DecksIndexDetailRequest) {
   const url = R["/decks/index-detail"];
   return {

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -395,7 +395,7 @@ function PageComponent({
             >
               <span
                 className={cls(
-                  newBookmarkMutation.isLoading
+                  !newBookmarkMutation.isLoading
                     ? "i-ri-bookmark-line"
                     : "antd-spin",
                   "w-6 h-6"

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -2,12 +2,7 @@ import { Transition } from "@headlessui/react";
 import { tinyassert } from "@hiogawa/utils";
 import { isNil } from "@hiogawa/utils";
 import { toArraySetState, useRafLoop } from "@hiogawa/utils-react";
-import {
-  Form,
-  Link,
-  ShouldReloadFunction,
-  useLoaderData,
-} from "@remix-run/react";
+import { Form, Link, useLoaderData } from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
 import { useMutation } from "@tanstack/react-query";
 import {
@@ -85,13 +80,6 @@ export const loader = makeLoader(Controller, async function () {
   });
   return redirect(R["/"]);
 });
-
-export const unstable_shouldReload: ShouldReloadFunction = ({ submission }) => {
-  if (submission?.action === R["/bookmarks/new"]) {
-    return false;
-  }
-  return true;
-};
 
 //
 // action

--- a/app/utils/__tests__/practice-system.test.ts
+++ b/app/utils/__tests__/practice-system.test.ts
@@ -10,14 +10,14 @@ import { PracticeSystem } from "../practice-system";
 const NOW = new Date(677721600 * 1000);
 
 describe("PracticeSystem", () => {
-  const { user, video, captionEntries } = useUserVideo(2, {
+  const hook = useUserVideo({
     seed: __filename,
   });
 
   it("basic", async () => {
     // TODO: move to `use...` helpers
     const [deckId] = await Q.decks().insert({
-      userId: user().id,
+      userId: hook.user.id,
       name: __filename,
     });
     const deck = await Q.decks().where({ id: deckId }).first();
@@ -28,9 +28,9 @@ describe("PracticeSystem", () => {
       text: "Bonjour à tous",
       side: 0,
       offset: 8,
-      userId: user().id,
-      videoId: video().id,
-      captionEntryId: captionEntries()[0].id,
+      userId: hook.user.id,
+      videoId: hook.video.id,
+      captionEntryId: hook.captionEntries[0].id,
     });
     const bookmarkEntry = await Q.bookmarkEntries()
       .where({ id: bookmarkEntryId })
@@ -38,7 +38,7 @@ describe("PracticeSystem", () => {
     tinyassert(bookmarkEntry);
 
     // instantiate practice system
-    const system = new PracticeSystem(user(), deck);
+    const system = new PracticeSystem(hook.user, deck);
 
     // create practice
     const [practiceEntryId] = await system.createPracticeEntries(
@@ -115,7 +115,7 @@ describe("PracticeSystem", () => {
   // TODO: setup data
   it("randomMode", async () => {
     const [deckId] = await Q.decks().insert({
-      userId: user().id,
+      userId: hook.user.id,
       name: __filename,
       randomMode: true,
     });
@@ -123,7 +123,7 @@ describe("PracticeSystem", () => {
     tinyassert(deck);
 
     // instantiate practice system
-    const system = new PracticeSystem(user(), deck);
+    const system = new PracticeSystem(hook.user, deck);
     const entry = await system.getNextPracticeEntry(NOW);
     expect(entry).toBe(undefined);
   });


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/228

## todo

- [x] new practice action
- [x] new practice entry
- [x] new bookmark entry
- [x] delete video
- [x] remove `unstable_shouldReload`
- [x] fix `bookmarkEntriesCount` cache on production, which was broken while testing before https://github.com/hi-ogawa/ytsub-v3/pull/231/commits/02660e3c374ad88e2b51f103ed01ebee9e895344