### PR TITLE
chore: setup source maps

### DIFF
--- a/app/misc/vercel.ts
+++ b/app/misc/vercel.ts
@@ -1,4 +1,6 @@
 import * as build from "@remix-run/dev/server-build";
 import { createRequestHandler } from "@remix-run/vercel";
 
+// TODO: @remix-run/vercel is deprecated https://github.com/remix-run/remix/pull/5964
+
 export default createRequestHandler({ build });

--- a/misc/build/bundle-vercel.ts
+++ b/misc/build/bundle-vercel.ts
@@ -10,6 +10,7 @@ import esbuild from "esbuild";
 // - https://github.com/evanw/esbuild/issues/1685#issuecomment-944916409
 
 esbuild.build({
+  logLevel: "info",
   entryPoints: ["./build/remix/production/server/index.js"],
   outfile: "./build/remix/production/server/index-bundled.js",
   bundle: true,

--- a/misc/build/bundle-vercel.ts
+++ b/misc/build/bundle-vercel.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import esbuild from "esbuild";
+
+// used by scripts/vercel.sh to
+// - bundle server app for simpler vercel deployment
+// - exclude node_modules from generating source map to reduce deployment size
+
+// references
+// - https://esbuild.github.io/plugins/
+// - https://github.com/evanw/esbuild/issues/1685#issuecomment-944916409
+
+esbuild.build({
+  entryPoints: ["./build/remix/production/server/index.js"],
+  outfile: "./build/remix/production/server/index-bundled.js",
+  bundle: true,
+  sourcemap: "inline",
+  platform: "node",
+  external: [
+    // exclude knex drivers except "mysql2"
+    "mysql",
+    "sqlite3",
+    "better-sqlite3",
+    "tedious",
+    "pg",
+    "oracledb",
+    "pg-query-stream",
+  ],
+  plugins: [
+    // https://github.com/evanw/esbuild/issues/1685#issuecomment-944916409
+    {
+      name: "no-source-map-node-modules",
+      setup(build) {
+        build.onLoad({ filter: /node_modules/ }, (args) => {
+          if (args.path.endsWith("js")) {
+            return {
+              contents:
+                fs.readFileSync(args.path, "utf8") +
+                "\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJtYXBwaW5ncyI6IkEifQ==",
+              loader: "default",
+            };
+          }
+        });
+      },
+    },
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vitest": "^0.29.3"
   },
   "volta": {
-    "node": "16.15.0"
+    "node": "16.20.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dev-pre": "pnpm build:css",
     "dev-e2e": "export NODE_ENV=test && pnpm dev-pre && PORT=3001 pnpm dev:remix",
     "dev-ui": "vite --host",
-    "dev:remix": "remix dev",
+    "dev:remix": "NODE_OPTIONS='--enable-source-maps' remix dev",
     "dev-coverage:remix": "c8 -o coverage/e2e-server -r text -r html --exclude build --exclude packages --exclude-after-remap node_modules/.bin/remix dev",
     "tsc": "tsc -b",
     "dev:tsc": "pnpm tsc --watch --preserveWatchOutput",

--- a/scripts/vercel.sh
+++ b/scripts/vercel.sh
@@ -12,15 +12,7 @@ pnpm build:css
 NODE_ENV=production BUILD_VERCEL=1 npx remix build --sourcemap
 
 # run esbuild again manually to bundle server app
-npx esbuild build/remix/production/server/index.js --sourcemap=inline --outfile=build/remix/production/server/index-bundled.js \
-  --bundle --platform=node \
-  --external:mysql \
-  --external:sqlite3 \
-  --external:better-sqlite3 \
-  --external:tedious \
-  --external:pg \
-  --external:oracledb \
-  --external:pg-query-stream
+node -r esbuild-register ./misc/build/bundle-vercel.ts
 
 #
 # setup files for `vercel deploy --prebuilt`

--- a/scripts/vercel.sh
+++ b/scripts/vercel.sh
@@ -39,7 +39,7 @@ npx esbuild build/remix/production/server/index.js --sourcemap=inline --outfile=
 #         index.func/
 #           .vc-config.json
 #           index-bundled.js
-#           index.js         (load index-bundled.js after process.setSourceMapsEnabled)
+#           index.js         (require index-bundled.js after process.setSourceMapsEnabled)
 #
 
 deploy_dir=build/remix/production/deploy
@@ -50,7 +50,7 @@ cp build/remix/production/server/index-bundled.js "$deploy_dir/.vercel/output/fu
 
 cat > "$deploy_dir/.vercel/output/functions/server/index.func/index.js" << "EOF"
 process.setSourceMapsEnabled(true);
-require("./index-bundled.js");
+module.exports = require("./index-bundled.js");
 EOF
 
 cat > "$deploy_dir/.vercel/output/config.json" << "EOF"


### PR DESCRIPTION
Note that we disable remix's automatic source-map-support installation since that somehow disturbs vitest/playwright's stacktrace:

https://github.com/hi-ogawa/ytsub-v3/blob/a6e3d307eaa88f36844c222106a58416103b8d46/patches/%40remix-run__node%401.15.0.patch#L9-L10

## bundle size

- before https://github.com/hi-ogawa/ytsub-v3/actions/runs/4706047937/jobs/8347023777#step:9:28

```
+ npx esbuild build/remix/production/server/index.js --outfile=build/remix/production/server/index-bundled.js --bundle --platform=node --external:mysql --external:sqlite3 --external:better-sqlite3 --external:tedious --external:pg --external:oracledb --external:pg-query-stream

  build/remix/production/server/index-bundled.js  9.4mb ⚠️
```

- after https://github.com/hi-ogawa/ytsub-v3/actions/runs/4706222540/jobs/8347307626#step:9:31

```
+ node -r esbuild-register ./misc/build/bundle-vercel.ts

  build/remix/production/server/index-bundled.js  10.2mb ⚠️
```

</details>

## todo

- [x] enable for production build (aws lambda, vercel serverless)
  - whole source map becomes 20MB (while actual source is about 9MB)
  - can we filter out all `node_modules`? https://github.com/evanw/esbuild/issues/1685
  - this works https://github.com/hi-ogawa/ytsub-v3/pull/263/commits/a70e591c83ff2a1b0ef91b01bdf47346a8f1f13d

## examples

<details><summary>dev</summary>

- before

```
    at Object.get error [as error] (/home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/types.js:43:31)
    at ZodObject.parse (/home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/types.js:141:22)
    at Controller.<anonymous> (/home/hiroshi/code/personal/ytsub-v3/build/remix/development/server/index.js:5944:112)
```

![image](https://user-images.githubusercontent.com/4232207/232181530-4555e781-45e6-4a54-820a-3ee7f88cd2d6.png)


- after

```
    at Object.get error [as error] (/home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/types.js:43:31)
    at ZodObject.parse (/home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/types.js:141:22)
    at Controller.<anonymous> (/home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/history-graph.tsx:57:61)
```

![image](https://user-images.githubusercontent.com/4232207/232181503-56d9083b-76ce-47c6-a1de-d720cfb19a16.png)

</details>

<details><summary>production</summary>

- error log of invalid trpc request by accessing `/trpc/bookmarks_historyChart`

```
  error: Error: require user
      at <anonymous> (/app/trpc/context.ts:36:3)
      ... 8 lines matching cause stack trace ...
      at async callLoaderOrAction (/var/task/index-bundled.js:4616:20) {
    code: 'INTERNAL_SERVER_ERROR',
    name: 'TRPCError',
    [cause]: TinyAssertionError: require user
        at <anonymous> (/app/trpc/context.ts:36:3)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async callRecursive (/var/task/index-bundled.js:228165:29)
```

![image](https://user-images.githubusercontent.com/4232207/232184752-d077e3d7-9bf8-460b-ad4a-a03fc3b0471e.png)

</details>
