### PR TITLE
test: fix flaky

### DIFF
--- a/app/routes/users/register.test.ts
+++ b/app/routes/users/register.test.ts
@@ -27,7 +27,8 @@ describe("register.action", () => {
       expect(found.timezone).toBe("+00:00");
       expect(found.createdAt).toEqual(found.updatedAt);
       expect(Math.abs(found.createdAt.getTime() - Date.now())).toBeLessThan(
-        1000
+        // ci flaky if 1000
+        5000
       );
 
       // redirect to root


### PR DESCRIPTION
Avoid getting this sometimes:

```
 FAIL  app/routes/users/register.test.ts > register.action > success > basic
AssertionError: expected 1001 to be less than 1000
 ❯ app/routes/users/register.test.ts:29:64
     27|       expect(found.timezone).toBe("+00:00");
     28|       expect(found.createdAt).toEqual(found.updatedAt);
     29|       expect(Math.abs(found.createdAt.getTime() - Date.now())).toBeLes…
       |                                                                ^
     30|         1000
     31|       );

  - Expected   "1001"
  + Received   "1000"
```

https://github.com/hi-ogawa/ytsub-v3/actions/runs/4706018614/jobs/8346978136#step:7:37