### PR TITLE
feat: more spinner during practice loop

### DIFF
--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -165,11 +165,13 @@ export function BookmarkEntryComponent({
   captionEntry,
   bookmarkEntry,
   showAutoplay,
+  isLoading,
 }: {
   video: VideoTable;
   captionEntry: CaptionEntryTable;
   bookmarkEntry: BookmarkEntryTable;
   showAutoplay?: boolean;
+  isLoading?: boolean; // for /decks/$id/practice
 }) {
   let [open, setOpen] = React.useState(false);
   let [autoplay, setAutoplay] = React.useState(false);
@@ -178,11 +180,6 @@ export function BookmarkEntryComponent({
     setAutoplay(true);
     setOpen(!open);
   }
-
-  // close when practice entry changed (/decks/$id/practice.tsx)
-  React.useEffect(() => {
-    setOpen(false);
-  }, [bookmarkEntry]);
 
   return (
     <div className="border flex flex-col" data-test="bookmark-entry">
@@ -208,7 +205,10 @@ export function BookmarkEntryComponent({
         </div>
         {showAutoplay && (
           <button
-            className="antd-btn antd-btn-ghost i-ri-play-line w-5 h-5"
+            className={cls(
+              "antd-btn antd-btn-ghost w-5 h-5",
+              isLoading ? "antd-spin" : "i-ri-play-line"
+            )}
             onClick={onClickAutoPlay}
           />
         )}

--- a/app/routes/decks/$id/practice.tsx
+++ b/app/routes/decks/$id/practice.tsx
@@ -1,5 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
-import { useLoaderData, useNavigate } from "@remix-run/react";
+import { useLoaderData, useNavigate, useNavigation } from "@remix-run/react";
 import { useMutation } from "@tanstack/react-query";
 import React from "react";
 import { toast } from "react-hot-toast";
@@ -151,8 +151,13 @@ function PracticeComponent({
     },
   });
 
+  // extra state for a bit nicer loading indicator
   const [lastActionType, setLastActionType] =
     React.useState<PracticeActionType>();
+
+  const navigation = useNavigation();
+  const isLoading =
+    newPracticeActionMutation.isLoading || navigation.state !== "idle";
 
   return (
     <>
@@ -164,6 +169,7 @@ function PracticeComponent({
           captionEntry={captionEntry}
           bookmarkEntry={bookmarkEntry}
           showAutoplay
+          isLoading={isLoading}
         />
       </div>
       <div className="flex justify-center pb-4">
@@ -173,11 +179,9 @@ function PracticeComponent({
               key={type}
               className={cls(
                 "antd-btn antd-btn-default px-3 py-0.5",
-                newPracticeActionMutation.isLoading &&
-                  lastActionType === type &&
-                  "antd-btn-loading"
+                isLoading && lastActionType === type && "antd-btn-loading"
               )}
-              disabled={newPracticeActionMutation.isLoading}
+              disabled={isLoading}
               onClick={() => {
                 setLastActionType(type);
                 newPracticeActionMutation.mutate({


### PR DESCRIPTION
During the reload navigation, action buttons weren't disabled.
So, we combine "react-query mutation loading" and "remix navigation loading" together.