### PR TITLE
feat: ability to load neighboring caption entries in `MiniPlayer`

### DIFF
--- a/app/components/collapse.tsx
+++ b/app/components/collapse.tsx
@@ -25,10 +25,20 @@ function useCollapseProps(): Partial<React.ComponentProps<typeof Transition>> {
   function uncollapse(el: HTMLDivElement) {
     const child = el.firstElementChild;
     tinyassert(child);
+    el.style.height = "0px";
+    forceStyle(el);
     el.style.height = child.clientHeight + "px";
   }
 
+  function reset(el: HTMLDivElement) {
+    el.style.height = "";
+  }
+
   function collapse(el: HTMLDivElement) {
+    const child = el.firstElementChild;
+    tinyassert(child);
+    el.style.height = child.clientHeight + "px";
+    forceStyle(el);
     el.style.height = "0px";
   }
 
@@ -38,11 +48,26 @@ function useCollapseProps(): Partial<React.ComponentProps<typeof Transition>> {
     uncollapse(el);
   }
 
+  function afterEnter() {
+    const el = refEl.current;
+    tinyassert(el);
+    reset(el);
+  }
+
   function beforeLeave() {
     const el = refEl.current;
     tinyassert(el);
     collapse(el);
   }
 
-  return { ref: React.useCallback(refCallback, []), beforeEnter, beforeLeave };
+  return {
+    ref: React.useCallback(refCallback, []),
+    beforeEnter,
+    afterEnter,
+    beforeLeave,
+  };
+}
+
+function forceStyle(el: Element) {
+  tinyassert(window.getComputedStyle(el).height);
 }

--- a/app/e2e/bookmarks.test.ts
+++ b/app/e2e/bookmarks.test.ts
@@ -5,7 +5,7 @@ import { useUserE2E } from "./helper";
 test.describe("bookmarks", () => {
   const user = useUserE2E(test, { seed: __filename });
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     await user.isReady;
     await importSeed(user.data.id);
   });

--- a/app/e2e/bookmarks.test.ts
+++ b/app/e2e/bookmarks.test.ts
@@ -17,4 +17,12 @@ test.describe("bookmarks", () => {
     await page.getByPlaceholder("Search text...").press("Enter");
     await page.getByText("진짜 힘든데").click();
   });
+
+  test("MiniPlayer", async ({ page }) => {
+    await user.signin(page);
+    await page.goto("/bookmarks");
+    await page.getByText("케플러 대박 기원").click();
+    await page.locator(".i-ri-upload-line").click();
+    await page.getByText("감사합니당~").click();
+  });
 });

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -339,7 +339,14 @@ export function MiniPlayer({
   });
 
   const loadCaptionEntryMutation = useMutation({
-    ...trpc.videos_getCaptionEntries.mutationOptions(),
+    mutationFn: async (direction: "previous" | "next") =>
+      trpc.videos_getCaptionEntries.mutationOptions().mutationFn({
+        videoId: initialEntry.videoId,
+        index:
+          direction === "previous"
+            ? captionEntries.at(0)!.index - 1
+            : captionEntries.at(-1)!.index + 1,
+      }),
     onSuccess: (data) => {
       toArraySetState(setCaptionEntries).push(data);
       toArraySetState(setCaptionEntries).sort((a, b) => a.index - b.index);
@@ -353,24 +360,26 @@ export function MiniPlayer({
     <div className="w-full flex flex-col items-center p-2 gap-2">
       <div className="w-full flex justify-start gap-1 px-1 text-xs">
         <button
-          className="antd-btn antd-btn-ghost i-ri-upload-line w-4 h-4"
+          className={cls(
+            "antd-btn antd-btn-ghost w-4 h-4",
+            loadCaptionEntryMutation.isLoading &&
+              loadCaptionEntryMutation.variables === "previous"
+              ? "antd-spin"
+              : "i-ri-upload-line"
+          )}
           disabled={loadCaptionEntryMutation.isLoading}
-          onClick={() =>
-            loadCaptionEntryMutation.mutate({
-              videoId: initialEntry.videoId,
-              index: captionEntries.at(0)!.index - 1,
-            })
-          }
+          onClick={() => loadCaptionEntryMutation.mutate("previous")}
         />
         <button
-          className="antd-btn antd-btn-ghost i-ri-download-line w-4 h-4"
+          className={cls(
+            "antd-btn antd-btn-ghost w-4 h-4",
+            loadCaptionEntryMutation.isLoading &&
+              loadCaptionEntryMutation.variables === "next"
+              ? "antd-spin"
+              : "i-ri-download-line"
+          )}
           disabled={loadCaptionEntryMutation.isLoading}
-          onClick={() =>
-            loadCaptionEntryMutation.mutate({
-              videoId: initialEntry.videoId,
-              index: captionEntries.at(-1)!.index + 1,
-            })
-          }
+          onClick={() => loadCaptionEntryMutation.mutate("next")}
         />
       </div>
       {captionEntries.map((captionEntry) => (

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -241,7 +241,7 @@ export function BookmarkEntryComponent({
 // TODO: refactor almost same logic from /videos/$id
 export function MiniPlayer({
   video,
-  captionEntry,
+  captionEntry: initialEntry,
   autoplay,
   defaultIsRepeating,
   highlight,
@@ -257,10 +257,10 @@ export function MiniPlayer({
   const [currentEntry, setCurrentEntry] = React.useState<CaptionEntry>();
   const [captionEntries, setCaptionEntries] = React.useState<
     CaptionEntryTable[]
-  >([captionEntry]);
+  >([initialEntry]);
   const [repeatingEntries, setRepeatingEntries] = React.useState<
     CaptionEntry[]
-  >(() => (defaultIsRepeating ? [captionEntry] : []));
+  >(() => (defaultIsRepeating ? [initialEntry] : []));
 
   //
   // handlers
@@ -272,7 +272,7 @@ export function MiniPlayer({
     // No-op if some text is selected (e.g. for google translate extension)
     if (document.getSelection()?.toString()) return;
 
-    if (toggle) {
+    if (toggle && entry === currentEntry) {
       if (isPlaying) {
         player.pauseVideo();
       } else {
@@ -293,7 +293,7 @@ export function MiniPlayer({
       videoId: video.videoId,
       playerVars: {
         // only integer supported. start from at least 1 second ahead.
-        start: Math.max(0, Math.floor(captionEntry.begin) - 1),
+        start: Math.max(0, Math.floor(initialEntry.begin) - 1),
         autoplay: autoplay ? 1 : 0,
         // TODO: no-op?
         cc_load_policy: 0,
@@ -357,7 +357,7 @@ export function MiniPlayer({
           disabled={loadCaptionEntryMutation.isLoading}
           onClick={() =>
             loadCaptionEntryMutation.mutate({
-              videoId: captionEntry.videoId,
+              videoId: initialEntry.videoId,
               index: captionEntries.at(0)!.index - 1,
             })
           }
@@ -367,7 +367,7 @@ export function MiniPlayer({
           disabled={loadCaptionEntryMutation.isLoading}
           onClick={() =>
             loadCaptionEntryMutation.mutate({
-              videoId: captionEntry.videoId,
+              videoId: initialEntry.videoId,
               index: captionEntries.at(-1)!.index + 1,
             })
           }
@@ -383,7 +383,7 @@ export function MiniPlayer({
           onClickEntryRepeat={toArraySetState(setRepeatingEntries).toggle}
           isPlaying={isPlaying}
           videoId={video.id}
-          highlight={highlight}
+          highlight={captionEntry === initialEntry ? highlight : undefined}
         />
       ))}
       <div className="relative w-full">

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -1,10 +1,12 @@
 import { Transition } from "@headlessui/react";
 import { isNil } from "@hiogawa/utils";
-import { useRafLoop } from "@hiogawa/utils-react";
+import { toArraySetState, useRafLoop } from "@hiogawa/utils-react";
 import { Link, NavLink, useLoaderData } from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
+import { useMutation } from "@tanstack/react-query";
 import { omit } from "lodash";
 import React from "react";
+import { toast } from "react-hot-toast";
 import type { z } from "zod";
 import { CollapseTransition } from "../../components/collapse";
 import { PaginationComponent, transitionProps } from "../../components/misc";
@@ -24,6 +26,7 @@ import type {
   VideoTable,
 } from "../../db/models";
 import { $R, ROUTE_DEF } from "../../misc/routes";
+import { trpc } from "../../trpc/client";
 import { Controller, makeLoader } from "../../utils/controller-utils";
 import { useDeserialize } from "../../utils/hooks";
 import { useLeafLoaderData } from "../../utils/loader-utils";
@@ -32,7 +35,7 @@ import type { PageHandle } from "../../utils/page-handle";
 import type { CaptionEntry } from "../../utils/types";
 import { toQuery } from "../../utils/url-data";
 import { YoutubePlayer, usePlayerLoader } from "../../utils/youtube";
-import { CaptionEntryComponent } from "../videos/$id";
+import { CaptionEntryComponent, findCurrentEntry } from "../videos/$id";
 
 export const handle: PageHandle = {
   navBarTitle: () => "Bookmarks",
@@ -173,7 +176,7 @@ export function BookmarkEntryComponent({
   showAutoplay?: boolean;
   isLoading?: boolean; // for /decks/$id/practice
 }) {
-  let [open, setOpen] = React.useState(true);
+  let [open, setOpen] = React.useState(false);
   let [autoplay, setAutoplay] = React.useState(false);
 
   function onClickAutoPlay() {
@@ -218,10 +221,7 @@ export function BookmarkEntryComponent({
           onClick={() => {}}
         />
       </div>
-      <CollapseTransition
-        show={open}
-        className="duration-300 h-0 overflow-hidden"
-      >
+      <CollapseTransition show={open} className="duration-300 overflow-hidden">
         <MiniPlayer
           video={video}
           captionEntry={captionEntry}
@@ -238,6 +238,7 @@ export function BookmarkEntryComponent({
   );
 }
 
+// TODO: refactor almost same logic from /videos/$id
 export function MiniPlayer({
   video,
   captionEntry,
@@ -253,8 +254,13 @@ export function MiniPlayer({
 }) {
   const [player, setPlayer] = React.useState<YoutubePlayer>();
   const [isPlaying, setIsPlaying] = React.useState(false);
-  const [isRepeating, setIsRepeating] = React.useState(defaultIsRepeating);
-  const { begin, end } = captionEntry;
+  const [currentEntry, setCurrentEntry] = React.useState<CaptionEntry>();
+  const [captionEntries, setCaptionEntries] = React.useState<
+    CaptionEntryTable[]
+  >([captionEntry]);
+  const [repeatingEntries, setRepeatingEntries] = React.useState<
+    CaptionEntry[]
+  >(() => (defaultIsRepeating ? [captionEntry] : []));
 
   //
   // handlers
@@ -278,10 +284,6 @@ export function MiniPlayer({
     }
   }
 
-  function onClickEntryRepeat() {
-    setIsRepeating(!isRepeating);
-  }
-
   //
   // effects
   //
@@ -290,8 +292,11 @@ export function MiniPlayer({
     {
       videoId: video.videoId,
       playerVars: {
-        start: Math.max(0, Math.floor(begin) - 1),
+        // only integer supported. start from at least 1 second ahead.
+        start: Math.max(0, Math.floor(captionEntry.begin) - 1),
         autoplay: autoplay ? 1 : 0,
+        // TODO: no-op?
+        cc_load_policy: 0,
       },
     },
     {
@@ -302,55 +307,85 @@ export function MiniPlayer({
   useRafLoop(() => {
     if (!player) return;
 
-    setIsPlaying(player.getPlayerState() === 1);
+    const isPlaying = player.getPlayerState() === 1;
+    setIsPlaying(isPlaying);
 
-    if (isRepeating) {
-      const currentTime = player.getCurrentTime();
+    if (!isPlaying) return;
+
+    const currentTime = player.getCurrentTime();
+    let nextEntry = findCurrentEntry(captionEntries, currentTime);
+
+    // repeat mode
+    if (repeatingEntries.length > 0) {
+      // update player
+      const begin = Math.min(...repeatingEntries.map((entry) => entry.begin));
+      const end = Math.max(...repeatingEntries.map((entry) => entry.end));
       if (currentTime < begin || end < currentTime) {
         player.seekTo(begin);
       }
+
+      // predict `nextEntry`
+      if (
+        nextEntry &&
+        currentEntry &&
+        nextEntry.index === currentEntry.index + 1 &&
+        repeatingEntries.at(-1) === currentEntry
+      ) {
+        nextEntry = repeatingEntries[0];
+      }
     }
+
+    setCurrentEntry(nextEntry);
+  });
+
+  const loadCaptionEntryMutation = useMutation({
+    ...trpc.videos_getCaptionEntries.mutationOptions(),
+    onSuccess: (data) => {
+      toArraySetState(setCaptionEntries).push(data);
+      toArraySetState(setCaptionEntries).sort((a, b) => a.index - b.index);
+    },
+    onError: () => {
+      toast.error("Failed to load caption");
+    },
   });
 
   return (
     <div className="w-full flex flex-col items-center p-2 gap-2">
       <div className="w-full flex justify-start gap-1 px-1 text-xs">
-        <button className="antd-btn antd-btn-ghost i-ri-upload-line w-4 h-4" />
-        <button className="antd-btn antd-btn-ghost i-ri-download-line w-4 h-4" />
+        <button
+          className="antd-btn antd-btn-ghost i-ri-upload-line w-4 h-4"
+          disabled={loadCaptionEntryMutation.isLoading}
+          onClick={() =>
+            loadCaptionEntryMutation.mutate({
+              videoId: captionEntry.videoId,
+              index: captionEntries.at(0)!.index - 1,
+            })
+          }
+        />
+        <button
+          className="antd-btn antd-btn-ghost i-ri-download-line w-4 h-4"
+          disabled={loadCaptionEntryMutation.isLoading}
+          onClick={() =>
+            loadCaptionEntryMutation.mutate({
+              videoId: captionEntry.videoId,
+              index: captionEntries.at(-1)!.index + 1,
+            })
+          }
+        />
       </div>
-      <CaptionEntryComponent
-        entry={captionEntry}
-        // currentEntry={captionEntry}
-        repeatingEntries={isRepeating ? [captionEntry] : []}
-        onClickEntryPlay={onClickEntryPlay}
-        onClickEntryRepeat={onClickEntryRepeat}
-        isPlaying={isPlaying}
-        videoId={video.id}
-        // border={false}
-        highlight={highlight}
-      />
-      <CaptionEntryComponent
-        entry={captionEntry}
-        // currentEntry={captionEntry}
-        repeatingEntries={isRepeating ? [captionEntry] : []}
-        onClickEntryPlay={onClickEntryPlay}
-        onClickEntryRepeat={onClickEntryRepeat}
-        isPlaying={isPlaying}
-        videoId={video.id}
-        // border={false}
-        highlight={highlight}
-      />
-      <CaptionEntryComponent
-        entry={captionEntry}
-        // currentEntry={captionEntry}
-        repeatingEntries={isRepeating ? [captionEntry] : []}
-        onClickEntryPlay={onClickEntryPlay}
-        onClickEntryRepeat={onClickEntryRepeat}
-        isPlaying={isPlaying}
-        videoId={video.id}
-        // border={false}
-        highlight={highlight}
-      />
+      {captionEntries.map((captionEntry) => (
+        <CaptionEntryComponent
+          key={captionEntry.id}
+          entry={captionEntry}
+          currentEntry={currentEntry}
+          repeatingEntries={repeatingEntries}
+          onClickEntryPlay={onClickEntryPlay}
+          onClickEntryRepeat={toArraySetState(setRepeatingEntries).toggle}
+          isPlaying={isPlaying}
+          videoId={video.id}
+          highlight={highlight}
+        />
+      ))}
       <div className="relative w-full">
         <div className="relative pt-[56.2%]">
           <div

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -173,7 +173,7 @@ export function BookmarkEntryComponent({
   showAutoplay?: boolean;
   isLoading?: boolean; // for /decks/$id/practice
 }) {
-  let [open, setOpen] = React.useState(false);
+  let [open, setOpen] = React.useState(true);
   let [autoplay, setAutoplay] = React.useState(false);
 
   function onClickAutoPlay() {
@@ -313,16 +313,42 @@ export function MiniPlayer({
   });
 
   return (
-    <div className="w-full flex flex-col items-center p-2 pt-0 gap-2">
+    <div className="w-full flex flex-col items-center p-2 gap-2">
+      <div className="w-full flex justify-start gap-1 px-1 text-xs">
+        <button className="antd-btn antd-btn-ghost i-ri-upload-line w-4 h-4" />
+        <button className="antd-btn antd-btn-ghost i-ri-download-line w-4 h-4" />
+      </div>
       <CaptionEntryComponent
         entry={captionEntry}
-        currentEntry={captionEntry}
+        // currentEntry={captionEntry}
         repeatingEntries={isRepeating ? [captionEntry] : []}
         onClickEntryPlay={onClickEntryPlay}
         onClickEntryRepeat={onClickEntryRepeat}
         isPlaying={isPlaying}
         videoId={video.id}
-        border={false}
+        // border={false}
+        highlight={highlight}
+      />
+      <CaptionEntryComponent
+        entry={captionEntry}
+        // currentEntry={captionEntry}
+        repeatingEntries={isRepeating ? [captionEntry] : []}
+        onClickEntryPlay={onClickEntryPlay}
+        onClickEntryRepeat={onClickEntryRepeat}
+        isPlaying={isPlaying}
+        videoId={video.id}
+        // border={false}
+        highlight={highlight}
+      />
+      <CaptionEntryComponent
+        entry={captionEntry}
+        // currentEntry={captionEntry}
+        repeatingEntries={isRepeating ? [captionEntry] : []}
+        onClickEntryPlay={onClickEntryPlay}
+        onClickEntryRepeat={onClickEntryRepeat}
+        isPlaying={isPlaying}
+        videoId={video.id}
+        // border={false}
         highlight={highlight}
       />
       <div className="relative w-full">

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -393,6 +393,7 @@ export function MiniPlayer({
           isPlaying={isPlaying}
           videoId={video.id}
           highlight={captionEntry === initialEntry ? highlight : undefined}
+          isFocused={captionEntry === initialEntry}
         />
       ))}
       <div className="relative w-full">

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -88,7 +88,7 @@ export default function DeafultComponent() {
   return <PageComponent currentUser={currentUser} {...data} />;
 }
 
-function findCurrentEntry(
+export function findCurrentEntry(
   entries: CaptionEntry[],
   time: number
 ): CaptionEntry | undefined {

--- a/app/trpc/routes/videos.ts
+++ b/app/trpc/routes/videos.ts
@@ -45,4 +45,30 @@ export const trpcRoutesVideos = {
         db.delete(T.bookmarkEntries).where(E.eq(T.bookmarkEntries.videoId, id)),
       ]);
     }),
+
+  videos_getCaptionEntries: procedureBuilder
+    .use(middlewares.requireUser)
+    .input(
+      z.object({
+        videoId: z.number().int(),
+        index: z.number().int(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const found = await findOne(
+        db
+          .select()
+          .from(T.captionEntries)
+          .innerJoin(T.videos, E.eq(T.videos.id, T.captionEntries.videoId))
+          .where(
+            E.and(
+              E.eq(T.videos.id, input.videoId),
+              E.eq(T.videos.userId, ctx.user.id),
+              E.eq(T.captionEntries.index, input.index)
+            )
+          )
+      );
+      tinyassert(found);
+      return found.captionEntries;
+    }),
 };

--- a/app/utils/youtube.ts
+++ b/app/utils/youtube.ts
@@ -310,16 +310,19 @@ export async function fetchCaptionEntries({
 }
 
 //
-// Youtube Iframe API wrapper
+// Youtube Iframe API wrapper https://developers.google.com/youtube/iframe_api_reference
 //
 
 export type YoutubePlayerOptions = {
   videoId: string;
   height?: number;
   width?: number;
+  // https://developers.google.com/youtube/player_parameters#Parameters
   playerVars?: {
     autoplay?: 0 | 1;
     start?: number; // must be integer
+    // TODO: cc_load_policy = 0 cannot always turn off CC?
+    cc_load_policy?: 0 | 1;
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@hiogawa/isort-ts": "1.0.1",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.2",
-    "@iconify-json/ri": "^1.1.5",
+    "@iconify-json/ri": "^1.1.7",
     "@playwright/test": "^1.31.2",
     "@remix-run/dev": "1.15.0",
     "@remix-run/serve": "1.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ dependencies:
     version: 7.43.7(react@18.2.0)
   react-hot-toast:
     specifier: ^2.4.0
-    version: 2.4.0(react-dom@18.2.0)(react@18.2.0)
+    version: 2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0)
   react-remove-scroll:
     specifier: ^2.5.5
     version: 2.5.5(@types/react@18.0.28)(react@18.2.0)
@@ -121,10 +121,10 @@ devDependencies:
     version: 1.0.1(prettier@2.8.4)(typescript@4.9.5)
   '@hiogawa/unocss-preset-antd':
     specifier: 2.2.1-pre.2
-    version: 2.2.1-pre.2(unocss@0.50.6)
+    version: 2.2.1-pre.2(@unocss/preset-uno@0.51.4)(unocss@0.50.6)
   '@iconify-json/ri':
-    specifier: ^1.1.5
-    version: 1.1.5
+    specifier: ^1.1.7
+    version: 1.1.7
   '@playwright/test':
     specifier: ^1.31.2
     version: 1.31.2
@@ -214,7 +214,7 @@ devDependencies:
     version: 4.9.5
   unocss:
     specifier: ^0.50.6
-    version: 0.50.6(vite@4.2.0)
+    version: 0.50.6(postcss@8.4.21)(vite@4.2.0)
   vite:
     specifier: ^4.2.0
     version: 4.2.0(@types/node@16.11.35)
@@ -2054,15 +2054,16 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /@hiogawa/unocss-preset-antd@2.2.1-pre.2(unocss@0.50.6):
+  /@hiogawa/unocss-preset-antd@2.2.1-pre.2(@unocss/preset-uno@0.51.4)(unocss@0.50.6):
     resolution: {integrity: sha512-IyLBst49BiscFZ+lcO1d2fJ7S7YhEK+ikgZNymtgbcMYhIbgzY6Qju4FW5BpBivQ3csMblzvgz+sfJDaXC0viw==}
     peerDependencies:
       '@unocss/preset-uno': '*'
       unocss: '*'
     dependencies:
+      '@unocss/preset-uno': 0.51.4
       '@unocss/reset': 0.48.5
       local-pkg: 0.4.3
-      unocss: 0.50.6(vite@4.2.0)
+      unocss: 0.50.6(postcss@8.4.21)(vite@4.2.0)
     dev: true
 
   /@hiogawa/utils-react@1.2.0(react@18.2.0):
@@ -2077,8 +2078,8 @@ packages:
     resolution: {integrity: sha512-7TOIw9EdYT6ViJ6HP68i9yD3bAHiEBaPVzYselDqoxObIVrwM6KV/JlhOOHia3/N6fY0rRj0fTn5sz03rQWFYA==}
     dev: false
 
-  /@iconify-json/ri@1.1.5:
-    resolution: {integrity: sha512-OrxKcKFHanTSPmU5esvSn5YfpNgjwJJ+6rkK1I1pIRCPXfuvmlTJGUjf+L5ZQHUiMWLQz+M2bqXx8iBUtW35Gg==}
+  /@iconify-json/ri@1.1.7:
+    resolution: {integrity: sha512-ra80AV2Q0wFuzT3YB48DKy0q3IWmmIh2ZbDnMGNX2Wz1lOx9PHgcewVvThk8OaUJOeGkneTMAzKQ64MRrOXEpg==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: true
@@ -2710,6 +2711,16 @@ packages:
     resolution: {integrity: sha512-WMIp8xr7YSlID2whqfRGLwagp59e6u4ckPACEpoDOW8sTeSPRZm54hxPhuWXD1SQuqcwHPMtM9nzGD8UOnqQxA==}
     dev: true
 
+  /@unocss/core@0.51.4:
+    resolution: {integrity: sha512-glPBN989gJNNVzjulH6NlLAekBLuZbsFRIDqwZ1ZaoWY6teu8Z6uo3pqFCy+ibjxZSEha77BcnKfDzd2Hccsdw==}
+    dev: true
+
+  /@unocss/extractor-arbitrary-variants@0.51.4:
+    resolution: {integrity: sha512-WfRsMEYthIkZjdTaTpzquTMtsb+GCp18tHM3CjlR9fsM7BGDF1rmMwcqWDzQc+wtiW+mzQFybL3chBgNdPloYA==}
+    dependencies:
+      '@unocss/core': 0.51.4
+    dev: true
+
   /@unocss/inspector@0.50.6:
     resolution: {integrity: sha512-6nX1YtaL67ohn/PfSSBv3npJ8qZcdc7S9X2zE6PUD/xhwtz7Bohx9I/KtmFdjJz5WeeGR7di0uYC6xsAcFLndQ==}
     dependencies:
@@ -2717,9 +2728,11 @@ packages:
       sirv: 2.0.2
     dev: true
 
-  /@unocss/postcss@0.50.6:
+  /@unocss/postcss@0.50.6(postcss@8.4.21):
     resolution: {integrity: sha512-pRPBVPmwjsVu3v1T0hQuqq3L4K74Wobo6pGDypvK/MuzWdWDhHiktWwmXGNxlYSWK7mGJBIa+vI10pp4e15OUw==}
     engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
     dependencies:
       '@unocss/config': 0.50.6
       '@unocss/core': 0.50.6
@@ -2751,6 +2764,13 @@ packages:
       '@unocss/core': 0.50.6
     dev: true
 
+  /@unocss/preset-mini@0.51.4:
+    resolution: {integrity: sha512-Ft/RQF+8KLooMTP/Qnl6qvxI/Gubi1ROsTTQLlgy3/cGxvoC2uBM4VpJFnTurJAX73IX9WJeA0IQSLfF+fXtIw==}
+    dependencies:
+      '@unocss/core': 0.51.4
+      '@unocss/extractor-arbitrary-variants': 0.51.4
+    dev: true
+
   /@unocss/preset-tagify@0.50.6:
     resolution: {integrity: sha512-ZyG/SJMobn4GZMbgrZOxT59ARp22LwgJGArCwJVosh3rraRVlb+B4x6ctMl6JOiLG5B1lHT9vZ92//u51Y0WTw==}
     dependencies:
@@ -2772,6 +2792,14 @@ packages:
       '@unocss/preset-wind': 0.50.6
     dev: true
 
+  /@unocss/preset-uno@0.51.4:
+    resolution: {integrity: sha512-akB0CWo60dzQ3N7WuqrfYLNOXrGlZQt7Pvtac3U7oAMw/Rmc9MXSkAF9ONpP3rm8dFucAi8L9+ZZGz18MjZL4w==}
+    dependencies:
+      '@unocss/core': 0.51.4
+      '@unocss/preset-mini': 0.51.4
+      '@unocss/preset-wind': 0.51.4
+    dev: true
+
   /@unocss/preset-web-fonts@0.50.6:
     resolution: {integrity: sha512-81meQMAq2lOy7k5qHQZ2EGWN5iJQUJOLl8dc9dxIo1eZPgiZQruxTVr4AkNVH5LRFcjHs/1sDb2CYxAiakwTVg==}
     dependencies:
@@ -2784,6 +2812,13 @@ packages:
     dependencies:
       '@unocss/core': 0.50.6
       '@unocss/preset-mini': 0.50.6
+    dev: true
+
+  /@unocss/preset-wind@0.51.4:
+    resolution: {integrity: sha512-QrY2CLl507cetAKNtmPMOIuFBv4og8+zi5GsDwKBdHDBT/BcmQg8dq8xnlg5hVV0BlbaV+EqMeU9T9Xzgj3JyQ==}
+    dependencies:
+      '@unocss/core': 0.51.4
+      '@unocss/preset-mini': 0.51.4
     dev: true
 
   /@unocss/reset@0.48.5:
@@ -3655,6 +3690,10 @@ packages:
 
   /csstype@3.0.11:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
+
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -4814,10 +4853,12 @@ packages:
       pinkie-promise: 2.0.1
     dev: true
 
-  /goober@2.1.12:
+  /goober@2.1.12(csstype@3.1.2):
     resolution: {integrity: sha512-yXHAvO08FU1JgTXX6Zn6sYCUFfB/OJSX8HHjDSgerZHZmFKAb08cykp5LBw5QnmyMcZyPRMqkdyHUSSzge788Q==}
     peerDependencies:
       csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.2
     dev: false
 
   /gopd@1.0.1:
@@ -4843,6 +4884,7 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /graceful-fs@4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
@@ -5421,14 +5463,14 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.9
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.9
 
   /keyv@4.5.2:
     resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
@@ -6841,14 +6883,14 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-hot-toast@2.4.0(react-dom@18.2.0)(react@18.2.0):
+  /react-hot-toast@2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==}
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
     dependencies:
-      goober: 2.1.12
+      goober: 2.1.12(csstype@3.1.2)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -7927,7 +7969,7 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  /unocss@0.50.6(vite@4.2.0):
+  /unocss@0.50.6(postcss@8.4.21)(vite@4.2.0):
     resolution: {integrity: sha512-7cKiIB/ssAPvCDUcFMs0jm0FzIyQKfgIjUzBYZ5dVFthOvN5dcFh7bCZE9dIM862n7oW8FjbkTxwdTbRqqJQVQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -7939,7 +7981,7 @@ packages:
       '@unocss/astro': 0.50.6(vite@4.2.0)
       '@unocss/cli': 0.50.6
       '@unocss/core': 0.50.6
-      '@unocss/postcss': 0.50.6
+      '@unocss/postcss': 0.50.6(postcss@8.4.21)
       '@unocss/preset-attributify': 0.50.6
       '@unocss/preset-icons': 0.50.6
       '@unocss/preset-mini': 0.50.6
@@ -7955,6 +7997,7 @@ packages:
       '@unocss/transformer-variant-group': 0.50.6
       '@unocss/vite': 0.50.6(vite@4.2.0)
     transitivePeerDependencies:
+      - postcss
       - rollup
       - supports-color
       - vite


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/273

<details>

![image](https://user-images.githubusercontent.com/4232207/232280151-2049b186-bd6c-4a7b-a6b4-9cf9ef138632.png)

</details>

## todo

- [x] test
- [ ] (later) refactoring
  - with this feature, `MiniPlayer` is going to have mostly same states as `/videos/$id` component (except bookmark floating button and auto scroll)
- [ ] (later) feature tweak
  - might want to fetch multiple at once?