### PR TITLE
fix: fix MiniPlayer autoplay

### DIFF
--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -293,15 +293,17 @@ export function MiniPlayer({
     {
       videoId: video.videoId,
       playerVars: {
-        // only integer supported. start from at least 1 second ahead.
         start: Math.max(0, Math.floor(initialEntry.begin) - 1),
-        autoplay: autoplay ? 1 : 0,
-        // TODO: no-op?
-        cc_load_policy: 0,
       },
     },
     {
-      onSuccess: setPlayer,
+      onSuccess: (player) => {
+        setPlayer(player);
+        // autoplay manually since it seems playerVars.autoplay doesn't work for mobile
+        if (autoplay) {
+          player.playVideo();
+        }
+      },
     }
   );
 

--- a/app/utils/youtube.ts
+++ b/app/utils/youtube.ts
@@ -319,10 +319,7 @@ export type YoutubePlayerOptions = {
   width?: number;
   // https://developers.google.com/youtube/player_parameters#Parameters
   playerVars?: {
-    autoplay?: 0 | 1;
     start?: number; // must be integer
-    // TODO: cc_load_policy = 0 cannot always turn off CC?
-    cc_load_policy?: 0 | 1;
   };
 };
 


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/278

Maybe something changed on youtube side to break `autoplay` on mobile.
Thus, we do autoplay manually by mutation onSuccess callback.