### PR TITLE
refactor: simplify practice randomMode query

### DIFF
--- a/app/e2e/decks.test.ts
+++ b/app/e2e/decks.test.ts
@@ -119,7 +119,6 @@ test.describe("decks", () => {
     await page.getByText("Progress").click();
     await page.getByText("0 | 187").click();
     await page.getByRole("button", { name: "GOOD" }).click();
-    await page.getByText("1 | 186").click();
   });
 });
 

--- a/app/e2e/decks.test.ts
+++ b/app/e2e/decks.test.ts
@@ -112,13 +112,14 @@ test.describe("decks", () => {
     await page.getByTestId("SelectWrapper-graphType").selectOption("queue");
   });
 
+  // TODO: detailed test with non randomMode?
   test("practice", async ({ page }) => {
     await user.signin(page);
     await page.goto("/decks");
     await page.getByRole("link", { name: "Korean" }).click();
     await page.getByText("Progress").click();
-    await page.getByText("0 | 187").click();
-    await page.getByRole("button", { name: "GOOD" }).click();
+    await page.getByText("0 | 140").click();
+    await page.getByRole("button", { name: "AGAIN" }).click();
   });
 });
 

--- a/app/e2e/decks.test.ts
+++ b/app/e2e/decks.test.ts
@@ -117,9 +117,9 @@ test.describe("decks", () => {
     await page.goto("/decks");
     await page.getByRole("link", { name: "Korean" }).click();
     await page.getByText("Progress").click();
-    await page.getByText("0 | 140").click();
-    await page.getByRole("button", { name: "AGAIN" }).click();
-    await page.getByText("1 | 139").click();
+    await page.getByText("0 | 187").click();
+    await page.getByRole("button", { name: "GOOD" }).click();
+    await page.getByText("1 | 186").click();
   });
 });
 

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -6,7 +6,7 @@ import consola from "consola";
 import { range, zip } from "lodash";
 import { z } from "zod";
 import { client } from "../db/client.server";
-import { E, T, db, findOne } from "../db/drizzle-client.server";
+import { findOne } from "../db/drizzle-client.server";
 import {
   Q,
   deleteOrphans,
@@ -23,7 +23,8 @@ import {
 import { exec, streamToString } from "../utils/node.server";
 import {
   queryDeckPracticeEntriesCountByQueueType,
-  queryNextPracticeEntryRandomMode,
+  queryPracticeEntryRandomMode,
+  queryPracticeEntryRandomModeSeed,
 } from "../utils/practice-system";
 import { NewVideo, fetchCaptionEntries } from "../utils/youtube";
 import { finalizeServer, initializeServer } from "./initialize-server";
@@ -262,17 +263,14 @@ cli
 
 async function commandDebugPracticeRandomMode(argsRaw: unknown) {
   const args = commandDebugPracticeModeArgs.parse(argsRaw);
-  const deck = await findOne(
-    db.select().from(T.decks).where(E.eq(T.decks.id, args.deckId))
-  );
-  tinyassert(deck);
-  const seed = args.seed ?? deck?.updatedAt.getTime();
-  const { query, ...misc } = queryNextPracticeEntryRandomMode(
+  const seed =
+    args.seed ?? (await queryPracticeEntryRandomModeSeed(args.deckId));
+  const { query, ...meta } = queryPracticeEntryRandomMode(
     args.deckId,
     args.now,
     seed
   );
-  console.log(misc);
+  console.log({ seed, meta });
   console.log(await query.limit(args.limit));
 }
 

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -267,12 +267,12 @@ async function commandDebugPracticeRandomMode(argsRaw: unknown) {
   );
   tinyassert(deck);
   const seed = args.seed ?? deck?.updatedAt.getTime();
-  const { query, ...misc } = queryNextPracticeEntryRandomMode(
+  const { query, ...meta } = queryNextPracticeEntryRandomMode(
     args.deckId,
     args.now,
     seed
   );
-  console.log(misc);
+  console.log({ seed, meta });
   console.log(await query.limit(args.limit));
 }
 

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -6,7 +6,7 @@ import consola from "consola";
 import { range, zip } from "lodash";
 import { z } from "zod";
 import { client } from "../db/client.server";
-import { findOne } from "../db/drizzle-client.server";
+import { E, T, db, findOne } from "../db/drizzle-client.server";
 import {
   Q,
   deleteOrphans,
@@ -23,8 +23,7 @@ import {
 import { exec, streamToString } from "../utils/node.server";
 import {
   queryDeckPracticeEntriesCountByQueueType,
-  queryPracticeEntryRandomMode,
-  queryPracticeEntryRandomModeSeed,
+  queryNextPracticeEntryRandomMode,
 } from "../utils/practice-system";
 import { NewVideo, fetchCaptionEntries } from "../utils/youtube";
 import { finalizeServer, initializeServer } from "./initialize-server";
@@ -263,14 +262,17 @@ cli
 
 async function commandDebugPracticeRandomMode(argsRaw: unknown) {
   const args = commandDebugPracticeModeArgs.parse(argsRaw);
-  const seed =
-    args.seed ?? (await queryPracticeEntryRandomModeSeed(args.deckId));
-  const { query, ...meta } = queryPracticeEntryRandomMode(
+  const deck = await findOne(
+    db.select().from(T.decks).where(E.eq(T.decks.id, args.deckId))
+  );
+  tinyassert(deck);
+  const seed = args.seed ?? deck?.updatedAt.getTime();
+  const { query, ...misc } = queryNextPracticeEntryRandomMode(
     args.deckId,
     args.now,
     seed
   );
-  console.log({ seed, meta });
+  console.log(misc);
   console.log(await query.limit(args.limit));
 }
 

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -14,7 +14,7 @@ import { useUser, useUserVideo } from "../misc/test-helper";
 import {
   PracticeSystem,
   hashInt32,
-  queryPracticeEntryRandomMode,
+  queryNextPracticeEntryRandomMode,
 } from "./practice-system";
 
 // >>> import datetime
@@ -200,7 +200,8 @@ describe("queryNextPracticeEntryRandomMode", () => {
   it("basic", async () => {
     const now = new Date("2023-04-10T00:00:00Z");
     const seed = 0;
-    const rows = await queryPracticeEntryRandomMode(deckId, now, seed).query;
+    const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed)
+      .query;
     expect(rows.length).toMatchInlineSnapshot("339");
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -1,10 +1,4 @@
-import {
-  groupBy,
-  mapValues,
-  range,
-  tinyassert,
-  uniq,
-} from "@hiogawa/utils";
+import { groupBy, mapValues, range, tinyassert, uniq } from "@hiogawa/utils";
 import { beforeAll, describe, expect, it } from "vitest";
 import { E, T, TT, db, findOne } from "../db/drizzle-client.server";
 import { Q } from "../db/models";

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -200,7 +200,8 @@ describe("queryNextPracticeEntryRandomMode", () => {
   it("basic", async () => {
     const now = new Date("2023-04-10T00:00:00Z");
     const seed = 0;
-    const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed);
+    const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed)
+      .query;
     expect(rows.length).toMatchInlineSnapshot("339");
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -1,5 +1,4 @@
 import {
-  DefaultMap,
   groupBy,
   mapValues,
   range,

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -2,7 +2,6 @@ import {
   DefaultMap,
   groupBy,
   mapValues,
-  objectPick,
   range,
   tinyassert,
   uniq,
@@ -202,11 +201,5 @@ describe("queryNextPracticeEntryRandomMode", () => {
     const seed = 0;
     const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed);
     expect(rows.length).toMatchInlineSnapshot("339");
-    console.log(rows);
-    console.log(
-      rows.map((row) =>
-        objectPick(row, ["queueType", "id", "updatedAt", "randomModeScore"])
-      )
-    );
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -14,7 +14,7 @@ import { useUser, useUserVideo } from "../misc/test-helper";
 import {
   PracticeSystem,
   hashInt32,
-  queryNextPracticeEntryRandomMode,
+  queryPracticeEntryRandomMode,
 } from "./practice-system";
 
 // >>> import datetime
@@ -200,8 +200,7 @@ describe("queryNextPracticeEntryRandomMode", () => {
   it("basic", async () => {
     const now = new Date("2023-04-10T00:00:00Z");
     const seed = 0;
-    const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed)
-      .query;
+    const rows = await queryPracticeEntryRandomMode(deckId, now, seed).query;
     expect(rows.length).toMatchInlineSnapshot("339");
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -170,17 +170,17 @@ describe("randomMode", () => {
       deck.updatedAt = new Date(deck.updatedAt.getTime() + 1); // force mutating seed since `updateAt` is not precise enough
     }
     // NEW should be picked most often
-    const countMap = new DefaultMap(
-      () => 0,
-      [
-        ...mapValues(
-          groupBy(entries, (e) => e.queueType),
-          (group) => group.length
-        ),
-      ]
+    const countMap = mapValues(
+      groupBy(entries, (e) => e.queueType),
+      (group) => group.length
     );
-    expect(countMap.get("NEW")).greaterThan(countMap.get("LEARN"));
-    expect(countMap.get("NEW")).greaterThan(countMap.get("REVIEW"));
+    expect(countMap).toMatchInlineSnapshot(`
+      Map {
+        "NEW" => 88,
+        "REVIEW" => 2,
+        "LEARN" => 10,
+      }
+    `);
     // should pick mostly random practice entries
     expect(uniq(entries.map((e) => e.id)).length).greaterThan(n - 5);
   });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -204,7 +204,9 @@ describe("queryNextPracticeEntryRandomMode", () => {
     expect(rows.length).toMatchInlineSnapshot("339");
     console.log(rows);
     console.log(
-      rows.map((row) => objectPick(row, ["queueType", "id", "updatedAt", "_"]))
+      rows.map((row) =>
+        objectPick(row, ["queueType", "id", "updatedAt", "randomModeScore"])
+      )
     );
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -13,6 +13,7 @@ import { importSeed } from "../misc/seed-utils";
 import { useUser, useUserVideo } from "../misc/test-helper";
 import {
   PracticeSystem,
+  hashInt32,
   queryNextPracticeEntryRandomMode,
 } from "./practice-system";
 
@@ -201,5 +202,30 @@ describe("queryNextPracticeEntryRandomMode", () => {
     const seed = 0;
     const rows = await queryNextPracticeEntryRandomMode(deckId, now, seed);
     expect(rows.length).toMatchInlineSnapshot("339");
+  });
+});
+
+describe("hashInt32", () => {
+  it("basic", async () => {
+    const xs = range(1000).map((i) => hashInt32(i + 12345) / 2 ** 32);
+
+    const bins = range(10).map(() => 0);
+    for (const x of xs) {
+      bins[Math.floor(x * bins.length)]++;
+    }
+    expect(bins).toMatchInlineSnapshot(`
+      [
+        107,
+        91,
+        75,
+        102,
+        114,
+        102,
+        99,
+        120,
+        100,
+        90,
+      ]
+    `);
   });
 });

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -1,4 +1,4 @@
-import crypto from "node:crypto";
+import crypto from "crypto";
 import { tinyassert } from "@hiogawa/utils";
 import { Temporal } from "@js-temporal/polyfill";
 import { difference, range } from "lodash";

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -348,7 +348,7 @@ export function queryNextPracticeEntryRandomMode(
           )
         )
         +
-        LEAST(0.5, 0.1 / (60 * 60 * 24 * 7) * (UNIX_TIMESTAMP(${now}) - UNIX_TIMESTAMP(scheduledAt)))
+        0.1 * LEAST(5, (UNIX_TIMESTAMP(${now}) - UNIX_TIMESTAMP(scheduledAt)) / (60 * 60 * 24 * 7))
         +
         2 * (${T.practiceEntries.queueType} = ${randQueueType})
       )`.as(RANDOM_MODE_SCORE_ALIAS),
@@ -366,7 +366,7 @@ export function queryNextPracticeEntryRandomMode(
 }
 
 // https://nullprogram.com/blog/2018/07/31/
-function hashInt32(x: number) {
+export function hashInt32(x: number) {
   x ^= x >>> 16;
   x = Math.imul(x, 0x21f0aaad);
   x ^= x >>> 15;

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -148,7 +148,7 @@ export class PracticeSystem {
           )
         )
         .orderBy(
-          // choose queueType by distribution (0.85, 0.1, 0.05), but ability to fallback to others when there's none
+          // choose queueType by the fixed probability (0.85, 0.1, 0.05) but with the ability to fallback to others when there's none
           sql`-(${T.practiceEntries.queueType} = ${seedUniform <= 0.85 ? "NEW" : seedUniform <= 0.95 ? "LEARN" : "REVIEW"})`,
           // then take the minimum of randomModeScore
           sql`randomModeScore`,

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -111,11 +111,8 @@ export class PracticeSystem {
     } = this.deck;
 
     if (randomMode) {
-      const { query } = queryNextPracticeEntryRandomMode(
-        this.deck.id,
-        now,
-        this.deck.updatedAt.getTime()
-      );
+      const seed = await queryPracticeEntryRandomModeSeed(this.deck.id);
+      const { query } = queryPracticeEntryRandomMode(this.deck.id, now, seed);
       const entry = await findOne(query);
       return entry;
     }
@@ -309,7 +306,22 @@ export async function queryDeckPracticeEntriesCountByQueueType(
   ) as any;
 }
 
-export function queryNextPracticeEntryRandomMode(
+export async function queryPracticeEntryRandomModeSeed(
+  deckId: number
+): Promise<number> {
+  // use last practice actions's timestamp as a seed
+  // since it's stable until next `createPracticeAction`
+  const lastPracticeAction = await findOne(
+    db
+      .select()
+      .from(T.practiceActions)
+      .where(E.eq(T.practiceActions.deckId, deckId))
+      .orderBy(E.desc(T.practiceActions.createdAt))
+  );
+  return lastPracticeAction?.createdAt.getTime() ?? 0;
+}
+
+export function queryPracticeEntryRandomMode(
   deckId: number,
   now: Date,
   seed: number

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -327,9 +327,9 @@ export function queryNextPracticeEntryRandomMode(
       // RANDOM(HASH(practiceAction) ^ seedInt)  (in [0, 1))
       // +
       // (scheduledAt bonus)                     (in [0, 0.5])
-      _: sql<number>`(
+      randomModeScore: sql<number>`(
         RAND(
-          UNHEX(
+          CONV(
             SUBSTRING(
               HEX(
                 UNHEX(SHA1(${T.practiceEntries.id})) ^
@@ -338,7 +338,9 @@ export function queryNextPracticeEntryRandomMode(
               ),
               1,
               8
-            )
+            ),
+            16,
+            10
           )
         )
         +

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -110,7 +110,7 @@ export class PracticeSystem {
     } = this.deck;
 
     // `decks.updatedAt` is used as a seed to shuffle everything for each `createPracticeAction` call,
-    // so that refreshing "practice" page refresh will keep showing the same practice entry.
+    // so that refreshing "practice" page will keep showing the same practice entry.
     const seedInt = hashInt32(String(this.deck.updatedAt.getTime()));
     const seedUniform = seedInt / 2 ** 32;
 

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -111,8 +111,11 @@ export class PracticeSystem {
     } = this.deck;
 
     if (randomMode) {
-      const seed = await queryPracticeEntryRandomModeSeed(this.deck.id);
-      const { query } = queryPracticeEntryRandomMode(this.deck.id, now, seed);
+      const { query } = queryNextPracticeEntryRandomMode(
+        this.deck.id,
+        now,
+        this.deck.updatedAt.getTime()
+      );
       const entry = await findOne(query);
       return entry;
     }
@@ -304,22 +307,7 @@ export async function queryDeckPracticeEntriesCountByQueueType(
   ) as any;
 }
 
-export async function queryPracticeEntryRandomModeSeed(
-  deckId: number
-): Promise<number> {
-  // use last practice actions's timestamp as a seed
-  // since it's stable until next `createPracticeAction`
-  const lastPracticeAction = await findOne(
-    db
-      .select()
-      .from(T.practiceActions)
-      .where(E.eq(T.practiceActions.deckId, deckId))
-      .orderBy(E.desc(T.practiceActions.createdAt))
-  );
-  return lastPracticeAction?.createdAt.getTime() ?? 0;
-}
-
-export function queryPracticeEntryRandomMode(
+export function queryNextPracticeEntryRandomMode(
   deckId: number,
   now: Date,
   seed: number

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -252,13 +252,11 @@ export class PracticeSystem {
       .where("id", practiceEntryId);
 
     // sql: update decks.practiceEntriesCountByQueueType
-    let qDecks;
-    if (queueType !== newQueueType) {
-      qDecks = updateDeckPracticeEntriesCountByQueueType(deckId, {
-        [queueType]: -1,
-        [newQueueType]: 1,
-      });
-    }
+    // (update deck even if queueType = newQueueType so that we can use `decks.updatedAt` as randomMode seed)
+    const qDecks = updateDeckPracticeEntriesCountByQueueType(deckId, {
+      [queueType]: queueType !== newQueueType ? -1 : 0,
+      [newQueueType]: queueType !== newQueueType ? 1 : 0,
+    });
 
     const [[id]] = await Promise.all([qActions, qEntries, qDecks]);
     return id;

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -111,7 +111,7 @@ export class PracticeSystem {
     } = this.deck;
 
     if (randomMode) {
-      const query = queryNextPracticeEntryRandomMode(
+      const { query } = queryNextPracticeEntryRandomMode(
         this.deck.id,
         now,
         this.deck.updatedAt.getTime()
@@ -362,7 +362,7 @@ export function queryNextPracticeEntryRandomMode(
     )
     .orderBy(E.desc(sql.raw(RANDOM_MODE_SCORE_ALIAS)));
 
-  return query;
+  return { query, randInt, randUniform, randQueueType };
 }
 
 // https://nullprogram.com/blog/2018/07/31/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cli-production": "pnpm dotenv-production node --require esbuild-register app/misc/cli.ts",
     "console": "node -r esbuild-register -r ./app/misc/console.ts",
     "console-staging": "pnpm dotenv-staging npm run console",
+    "console-production": "pnpm dotenv-production npm run console",
     "knex": "NODE_OPTIONS='-r esbuild-register' knex --knexfile app/db/knexfile.server.ts",
     "knex-staging": "pnpm dotenv-staging pnpm knex",
     "knex-production": "pnpm dotenv-production pnpm knex",


### PR DESCRIPTION
- a part of https://github.com/hi-ogawa/ytsub-v3/issues/208

Not sure how much that ugly `crossJoin` trick affects db read, but this is way simpler and should work same for the purpose.
Difference would be that practice pick changes when user update deck settings.