### PR TITLE
feat: practice action history list filter

### DIFF
--- a/app/components/misc.tsx
+++ b/app/components/misc.tsx
@@ -218,7 +218,7 @@ export function SelectWrapper<T>({
   value,
   options,
   onChange,
-  // these default works fine when `T extends string`
+  // convenient default when `T extends string`
   labelFn = String,
   keyFn = (value) => JSON.stringify({ value }), // wrap it so that `undefined` becomes `{}`
   ...selectProps

--- a/app/components/misc.tsx
+++ b/app/components/misc.tsx
@@ -210,63 +210,30 @@ export function QueryClientWrapper({ children }: React.PropsWithChildren) {
   );
 }
 
-// simple typed controlled select input wrapper
-export function SelectWrapper<T extends string>({
+//
+// simple select input wrapper with convenient typing
+//
+
+export function SelectWrapper<T>({
   value,
   options,
   onChange,
-  labelFn,
+  labelFn = String,
+  keyFn = (value) => JSON.stringify({ value }),
   ...selectProps
 }: {
   value: T;
   options: readonly T[];
   onChange: (value: T) => void;
   labelFn?: (value: T) => React.ReactNode;
+  keyFn?: (value: T) => React.Key;
 } & Omit<JSX.IntrinsicElements["select"], "value" | "onChange">) {
   return (
     <select
-      value={value}
-      onChange={(e) => onChange(options[e.target.selectedIndex])}
+      value={options.indexOf(value)}
+      onChange={(e) => onChange(options[Number(e.target.value)])}
       {...selectProps}
     >
-      {options.map((option) => (
-        <option key={option} value={option}>
-          {labelFn ? labelFn(option) : option}
-        </option>
-      ))}
-    </select>
-  );
-}
-
-export function SimpleSelectClearable<T>({
-  value,
-  onChange,
-  options,
-  keyFn = JSON.stringify,
-  labelFn = String,
-  placeholder,
-  ...selectProps
-}: {
-  value?: T;
-  onChange: (value?: T) => void;
-  options: readonly T[];
-  keyFn?: (value: T) => React.Key;
-  labelFn?: (value: T) => React.ReactNode;
-  placeholder: React.ReactNode;
-} & Omit<
-  JSX.IntrinsicElements["select"],
-  "value" | "onChange" | "placeholder"
->) {
-  const valueIndex = typeof value === "undefined" ? -1 : options.indexOf(value);
-  return (
-    <select
-      value={valueIndex}
-      onChange={(e) => {
-        onChange(options[Number(e.target.value)]);
-      }}
-      {...selectProps}
-    >
-      <option value={-1}>{placeholder}</option>
       {options.map((option, i) => (
         <option key={keyFn(option)} value={i}>
           {labelFn(option)}

--- a/app/components/misc.tsx
+++ b/app/components/misc.tsx
@@ -237,3 +237,41 @@ export function SelectWrapper<T extends string>({
     </select>
   );
 }
+
+export function SimpleSelectClearable<T>({
+  value,
+  onChange,
+  options,
+  keyFn = JSON.stringify,
+  labelFn = String,
+  placeholder,
+  ...selectProps
+}: {
+  value?: T;
+  onChange: (value?: T) => void;
+  options: readonly T[];
+  keyFn?: (value: T) => React.Key;
+  labelFn?: (value: T) => React.ReactNode;
+  placeholder: React.ReactNode;
+} & Omit<
+  JSX.IntrinsicElements["select"],
+  "value" | "onChange" | "placeholder"
+>) {
+  const valueIndex = typeof value === "undefined" ? -1 : options.indexOf(value);
+  return (
+    <select
+      value={valueIndex}
+      onChange={(e) => {
+        onChange(options[Number(e.target.value)]);
+      }}
+      {...selectProps}
+    >
+      <option value={-1}>{placeholder}</option>
+      {options.map((option, i) => (
+        <option key={keyFn(option)} value={i}>
+          {labelFn(option)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/components/misc.tsx
+++ b/app/components/misc.tsx
@@ -218,8 +218,9 @@ export function SelectWrapper<T>({
   value,
   options,
   onChange,
+  // these default works fine when `T extends string`
   labelFn = String,
-  keyFn = (value) => JSON.stringify({ value }),
+  keyFn = (value) => JSON.stringify({ value }), // wrap it so that `undefined` becomes `{}`
   ...selectProps
 }: {
   value: T;

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -211,6 +211,7 @@ export async function toCountQuery<
   return count;
 }
 
+// just for experiment and not actually used yet
 export function toDeleteQueryInner(sql: SQL, tableName: string): SQL {
   // replace
   //   select ... from

--- a/app/db/types.ts
+++ b/app/db/types.ts
@@ -10,7 +10,7 @@ export const Z_PRACTICE_ACTION_TYPES = z.enum([
   "GOOD",
   "EASY",
 ]);
-const Z_PRACTICE_QUEUE_TYPES = z.enum(["NEW", "LEARN", "REVIEW"]);
+export const Z_PRACTICE_QUEUE_TYPES = z.enum(["NEW", "LEARN", "REVIEW"]);
 
 export const PRACTICE_ACTION_TYPES = Z_PRACTICE_ACTION_TYPES.options;
 export const PRACTICE_QUEUE_TYPES = Z_PRACTICE_QUEUE_TYPES.options;

--- a/app/e2e/decks.test.ts
+++ b/app/e2e/decks.test.ts
@@ -107,9 +107,13 @@ test.describe("decks", () => {
     await page.getByText("this week").click();
 
     // change graph options
-    await page.getByTestId("SelectWrapper-rangeType").selectOption("month");
+    await page
+      .getByTestId("SelectWrapper-rangeType")
+      .selectOption({ label: "by month" });
     await page.getByText("this month").click();
-    await page.getByTestId("SelectWrapper-graphType").selectOption("queue");
+    await page
+      .getByTestId("SelectWrapper-graphType")
+      .selectOption({ label: "by queue" });
   });
 
   // TODO: detailed test with non randomMode?

--- a/app/misc/routes.ts
+++ b/app/misc/routes.ts
@@ -1,5 +1,6 @@
 import { tinyassert } from "@hiogawa/utils";
 import { z } from "zod";
+import { Z_PRACTICE_ACTION_TYPES, Z_PRACTICE_QUEUE_TYPES } from "../db/types";
 import { createGetProxy } from "../utils/proxy-utiils";
 
 // centralized route definitions to benefit from static analysis e.g.
@@ -60,7 +61,12 @@ export const ROUTE_DEF = {
   "/decks/import": {},
   "/decks/$id": {
     params: Z_ID_PARAMS,
-    query: Z_PAGINATION_QUERY,
+    query: z
+      .object({
+        // TODO
+        queueType: Z_PRACTICE_QUEUE_TYPES.optional(),
+      })
+      .merge(Z_PAGINATION_QUERY),
   },
   "/decks/$id/edit": {
     params: Z_ID_PARAMS,
@@ -72,6 +78,7 @@ export const ROUTE_DEF = {
     params: Z_ID_PARAMS,
     query: z
       .object({
+        actionType: Z_PRACTICE_ACTION_TYPES.optional(),
         practiceEntryId: z.coerce.number().int().optional(),
       })
       .merge(Z_PAGINATION_QUERY),

--- a/app/routes/decks/$id/history.test.ts
+++ b/app/routes/decks/$id/history.test.ts
@@ -65,6 +65,10 @@ describe("decks/id/history.loader", () => {
             "total": 0,
             "totalPage": 0,
           },
+          "query": {
+            "page": 1,
+            "perPage": 20,
+          },
           "rows": [],
         },
         "meta": {

--- a/app/routes/decks/$id/history.tsx
+++ b/app/routes/decks/$id/history.tsx
@@ -3,11 +3,16 @@ import {
   QueueTypeIcon,
   requireUserAndDeck,
 } from ".";
-import { useLoaderData } from "@remix-run/react";
+import { mapOption } from "@hiogawa/utils";
+import { useLoaderData, useNavigate } from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
 import React from "react";
+import type { z } from "zod";
 import { CollapseTransition } from "../../../components/collapse";
-import { PaginationComponent } from "../../../components/misc";
+import {
+  PaginationComponent,
+  SimpleSelectClearable,
+} from "../../../components/misc";
 import {
   E,
   T,
@@ -16,6 +21,7 @@ import {
   toPaginationResult,
 } from "../../../db/drizzle-client.server";
 import type { DeckTable, PaginationMetadata } from "../../../db/models";
+import { PRACTICE_ACTION_TYPES } from "../../../db/types";
 import { $R, ROUTE_DEF } from "../../../misc/routes";
 import { Controller, makeLoader } from "../../../utils/controller-utils";
 import { useDeserialize } from "../../../utils/hooks";
@@ -46,6 +52,7 @@ interface LoaderData {
     "practiceActions" | "bookmarkEntries" | "captionEntries" | "videos"
   >[];
   pagination: PaginationMetadata;
+  query: z.infer<(typeof ROUTE_DEF)["/decks/$id/history"]["query"]>;
 }
 
 export const loader = makeLoader(Controller, async function () {
@@ -77,19 +84,19 @@ export const loader = makeLoader(Controller, async function () {
       .where(
         E.and(
           E.eq(T.practiceActions.deckId, deck.id),
-          parsed.data.practiceEntryId
-            ? E.eq(
-                T.practiceActions.practiceEntryId,
-                parsed.data.practiceEntryId
-              )
-            : undefined
+          mapOption(parsed.data.actionType, (t) =>
+            E.eq(T.practiceActions.actionType, t)
+          ),
+          mapOption(parsed.data.practiceEntryId, (t) =>
+            E.eq(T.practiceActions.practiceEntryId, t)
+          )
         )
       )
       .orderBy(E.desc(T.practiceActions.createdAt)),
     parsed.data
   );
 
-  const res: LoaderData = { deck, rows, pagination };
+  const res: LoaderData = { deck, rows, pagination, query: parsed.data };
   return this.serialize(res);
 });
 
@@ -98,13 +105,33 @@ export const loader = makeLoader(Controller, async function () {
 //
 
 export default function DefaultComponent() {
-  const { rows, pagination }: LoaderData = useDeserialize(useLoaderData());
+  const { deck, rows, pagination, query }: LoaderData = useDeserialize(
+    useLoaderData()
+  );
+  const navigate = useNavigate();
 
   return (
     <>
       <div className="w-full flex justify-center">
         <div className="h-full w-full max-w-lg">
           <div className="h-full flex flex-col p-2 gap-2">
+            <div className="flex items-center gap-2 py-1">
+              Filter
+              <SimpleSelectClearable
+                className="antd-input p-1"
+                placeholder="Select..."
+                options={PRACTICE_ACTION_TYPES}
+                value={query.actionType}
+                onChange={(actionType) => {
+                  navigate(
+                    $R["/decks/$id/history"](
+                      { id: deck.id },
+                      actionType ? { actionType } : {}
+                    )
+                  );
+                }}
+              />
+            </div>
             {rows.length === 0 && <div>Empty</div>}
             {rows.map((row) => (
               <PracticeActionComponent key={row.practiceActions.id} {...row} />

--- a/app/routes/decks/$id/history.tsx
+++ b/app/routes/decks/$id/history.tsx
@@ -9,10 +9,7 @@ import { redirect } from "@remix-run/server-runtime";
 import React from "react";
 import type { z } from "zod";
 import { CollapseTransition } from "../../../components/collapse";
-import {
-  PaginationComponent,
-  SimpleSelectClearable,
-} from "../../../components/misc";
+import { PaginationComponent, SelectWrapper } from "../../../components/misc";
 import {
   E,
   T,
@@ -117,11 +114,11 @@ export default function DefaultComponent() {
           <div className="h-full flex flex-col p-2 gap-2">
             <div className="flex items-center gap-2 py-1">
               Filter
-              <SimpleSelectClearable
+              <SelectWrapper
                 className="antd-input p-1"
-                placeholder="Select..."
-                options={PRACTICE_ACTION_TYPES}
+                options={[undefined, ...PRACTICE_ACTION_TYPES]}
                 value={query.actionType}
+                labelFn={(v) => v ?? "Select..."}
                 onChange={(actionType) => {
                   navigate(
                     $R["/decks/$id/history"](


### PR DESCRIPTION
This would be convenient to go through all "AGAIN" actions for example.

## todo

- [ ] (later) organize `/decks/$id` route
  - the menu order can be 
    - practice -> action list -> chart -> entry list -> edit
    - we can probably remove bookmark
    - improved version of "action list" can be put to `/decks/$id` index page?

## screenshots

![image](https://user-images.githubusercontent.com/4232207/233014398-d065ced1-83d2-4e8a-9228-07007fdc758f.png)
