### PR TITLE
feat: tweak subtitle auto-scroll

### DIFF
--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -201,12 +201,21 @@ function PageComponent({
     }
 
     // auto scroll subtitle list
-    if (autoScroll && nextEntry && virtualizer.scrollElement) {
+    if (
+      autoScroll &&
+      nextEntry &&
+      nextEntry !== currentEntry &&
+      virtualizer.scrollElement
+    ) {
       const { scrollTop, clientHeight } = virtualizer.scrollElement;
       const currentCenter = scrollTop + clientHeight / 2;
+      const threshold = clientHeight / 6;
       const items = virtualizer.getVirtualItems();
       const currentItem = items.find((item) => item.index === nextEntry?.index);
-      if (!currentItem || Math.abs(currentItem.start - currentCenter) > 150) {
+      if (
+        !currentItem ||
+        Math.abs(currentItem.start - currentCenter) > threshold
+      ) {
         virtualizer.scrollToIndex(nextEntry.index, {
           align: "center",
           behavior: "auto",


### PR DESCRIPTION
Hard coded `150px` wasn't appropriate for mobile, so makes it adaptive abased on scroll height.
Also we can check this only when `nextEntry !== currentEntry`.