### PR TITLE
[db] perf: more deck based cache

### DIFF
--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -116,9 +116,7 @@ const decks = mysqlTable("decks", {
   easeMultiplier: float("easeMultiplier").notNull().default(DUMMY_DEFAULT),
   easeBonus: float("easeBonus").notNull().default(DUMMY_DEFAULT),
   randomMode: boolean("randomMode").notNull().default(DUMMY_DEFAULT),
-  // TODO: drop later
-  practiceEntriesCountByQueueType: json<DeckCache>("practiceEntriesCountByQueueType"),
-  // cache various things to avoid heavy SELECT query
+  // cache various things to reduce repeating heavy SELECT queries
   cache: json<DeckCache>("cache").notNull(),
 });
 

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -122,9 +122,9 @@ const decks = mysqlTable("decks", {
 
 // prettier-ignore
 interface DeckCache {
-  nextEntriesRandomMode?: { id: number }[];
-  practiceEntriesCountByQueueType?: Partial<Record<PracticeQueueType, number>>;
-  practiceActionsCountByActionType?: Partial<Record<PracticeActionType, number>>;
+  nextEntriesRandomMode: { id: number }[];
+  practiceEntriesCountByQueueType: Record<PracticeQueueType, number>;
+  practiceActionsCountByActionType: Record<PracticeActionType, number>;
 }
 
 const practiceEntries = mysqlTable("practiceEntries", {

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -20,7 +20,7 @@ import { uninitialized } from "../utils/misc";
 import type { PaginationParams } from "../utils/pagination";
 import knexfile from "./knexfile.server";
 import type { PaginationMetadata } from "./models";
-import type { PracticeActionType, PracticeQueueType } from "./types";
+import type { DeckCache, PracticeActionType, PracticeQueueType } from "./types";
 
 //
 // schema utils
@@ -120,13 +120,6 @@ const decks = mysqlTable("decks", {
   practiceEntriesCountByQueueType: json<Record<PracticeQueueType, number>>("practiceEntriesCountByQueueType").notNull().default(DUMMY_DEFAULT),
   cache: json<DeckCache>("cache").notNull(),
 });
-
-// prettier-ignore
-interface DeckCache {
-  nextEntriesRandomMode: { id: number }[];
-  practiceEntriesCountByQueueType: Record<PracticeQueueType, number>;
-  practiceActionsCountByActionType: Record<PracticeActionType, number>;
-}
 
 const practiceEntries = mysqlTable("practiceEntries", {
   id: serial("id").primaryKey(),

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -116,6 +116,7 @@ const decks = mysqlTable("decks", {
   easeMultiplier: float("easeMultiplier").notNull(),
   easeBonus: float("easeBonus").notNull(),
   randomMode: boolean("randomMode").notNull().default(DUMMY_DEFAULT),
+  // TODO: to be replaced by `cache`
   practiceEntriesCountByQueueType: json<Record<PracticeQueueType, number>>("practiceEntriesCountByQueueType").notNull().default(DUMMY_DEFAULT),
   cache: json<DeckCache>("cache").notNull().default(DUMMY_DEFAULT),
 });

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -111,13 +111,14 @@ const decks = mysqlTable("decks", {
   ...timestampColumns,
   //
   name: text("name").notNull(),
-  newEntriesPerDay: int("newEntriesPerDay").notNull(),
-  reviewsPerDay: int("reviewsPerDay").notNull(),
-  easeMultiplier: float("easeMultiplier").notNull(),
-  easeBonus: float("easeBonus").notNull(),
+  newEntriesPerDay: int("newEntriesPerDay").notNull().default(DUMMY_DEFAULT),
+  reviewsPerDay: int("reviewsPerDay").notNull().default(DUMMY_DEFAULT),
+  easeMultiplier: float("easeMultiplier").notNull().default(DUMMY_DEFAULT),
+  easeBonus: float("easeBonus").notNull().default(DUMMY_DEFAULT),
   randomMode: boolean("randomMode").notNull().default(DUMMY_DEFAULT),
-  // TODO: to be replaced by `cache`
-  practiceEntriesCountByQueueType: json<Record<PracticeQueueType, number>>("practiceEntriesCountByQueueType").notNull().default(DUMMY_DEFAULT),
+  // TODO: drop later
+  practiceEntriesCountByQueueType: json<DeckCache>("practiceEntriesCountByQueueType"),
+  // cache various things to avoid heavy SELECT query
   cache: json<DeckCache>("cache").notNull(),
 });
 

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -118,7 +118,7 @@ const decks = mysqlTable("decks", {
   randomMode: boolean("randomMode").notNull().default(DUMMY_DEFAULT),
   // TODO: to be replaced by `cache`
   practiceEntriesCountByQueueType: json<Record<PracticeQueueType, number>>("practiceEntriesCountByQueueType").notNull().default(DUMMY_DEFAULT),
-  cache: json<DeckCache>("cache").notNull().default(DUMMY_DEFAULT),
+  cache: json<DeckCache>("cache").notNull(),
 });
 
 // prettier-ignore

--- a/app/db/drizzle-client.server.ts
+++ b/app/db/drizzle-client.server.ts
@@ -117,7 +117,15 @@ const decks = mysqlTable("decks", {
   easeBonus: float("easeBonus").notNull(),
   randomMode: boolean("randomMode").notNull().default(DUMMY_DEFAULT),
   practiceEntriesCountByQueueType: json<Record<PracticeQueueType, number>>("practiceEntriesCountByQueueType").notNull().default(DUMMY_DEFAULT),
+  cache: json<DeckCache>("cache").notNull().default(DUMMY_DEFAULT),
 });
+
+// prettier-ignore
+interface DeckCache {
+  nextEntriesRandomMode?: { id: number }[];
+  practiceEntriesCountByQueueType?: Partial<Record<PracticeQueueType, number>>;
+  practiceActionsCountByActionType?: Partial<Record<PracticeActionType, number>>;
+}
 
 const practiceEntries = mysqlTable("practiceEntries", {
   id: serial("id").primaryKey(),

--- a/app/db/migrations/20230422063146_add-decks-cache.ts
+++ b/app/db/migrations/20230422063146_add-decks-cache.ts
@@ -3,10 +3,12 @@ import type { Knex } from "knex";
 export async function up(knex: Knex) {
   // ensures default value by application logic
   await knex.raw(
-    "ALTER TABLE `decks` ADD COLUMN `cache` json NOT NULL DEFAULT (json_object());"
+    "ALTER TABLE `decks` DROP COLUMN `practiceEntriesCountByQueueType`, ADD COLUMN `cache` json NOT NULL DEFAULT (json_object())"
   );
 }
 
 export async function down(knex: Knex) {
-  await knex.raw("ALTER TABLE `decks` DROP COLUMN `cache`;");
+  await knex.raw(
+    "ALTER TABLE `decks` ADD COLUMN `practiceEntriesCountByQueueType` json NOT NULL DEFAULT (json_object(_utf8mb4'NEW',0,_utf8mb4'LEARN',0,_utf8mb4'REVIEW',0)) AFTER `randomMode`"
+  );
 }

--- a/app/db/migrations/20230422063146_add-decks-cache.ts
+++ b/app/db/migrations/20230422063146_add-decks-cache.ts
@@ -1,7 +1,7 @@
 import type { Knex } from "knex";
 
 export async function up(knex: Knex) {
-  // ensures default value by application logic `resetDeckCache`
+  // ensures default value by application logic
   await knex.raw(
     "ALTER TABLE `decks` ADD COLUMN `cache` json NOT NULL DEFAULT (json_object());"
   );

--- a/app/db/migrations/20230422063146_add-decks-cache.ts
+++ b/app/db/migrations/20230422063146_add-decks-cache.ts
@@ -1,0 +1,11 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex) {
+  await knex.raw(
+    "ALTER TABLE `decks` ADD COLUMN `cache` json NOT NULL DEFAULT (json_object());"
+  );
+}
+
+export async function down(knex: Knex) {
+  await knex.raw("ALTER TABLE `decks` DROP COLUMN `cache`;");
+}

--- a/app/db/migrations/20230422063146_add-decks-cache.ts
+++ b/app/db/migrations/20230422063146_add-decks-cache.ts
@@ -9,6 +9,6 @@ export async function up(knex: Knex) {
 
 export async function down(knex: Knex) {
   await knex.raw(
-    "ALTER TABLE `decks` ADD COLUMN `practiceEntriesCountByQueueType` json NOT NULL DEFAULT (json_object(_utf8mb4'NEW',0,_utf8mb4'LEARN',0,_utf8mb4'REVIEW',0)) AFTER `randomMode`"
+    "ALTER TABLE `decks` DROP COLUMN `cache`, ADD COLUMN `practiceEntriesCountByQueueType` json NOT NULL DEFAULT (json_object(_utf8mb4'NEW',0,_utf8mb4'LEARN',0,_utf8mb4'REVIEW',0)) AFTER `randomMode`"
   );
 }

--- a/app/db/migrations/20230422063146_add-decks-cache.ts
+++ b/app/db/migrations/20230422063146_add-decks-cache.ts
@@ -1,6 +1,7 @@
 import type { Knex } from "knex";
 
 export async function up(knex: Knex) {
+  // ensures default value by application logic `resetDeckCache`
   await knex.raw(
     "ALTER TABLE `decks` ADD COLUMN `cache` json NOT NULL DEFAULT (json_object());"
   );

--- a/app/db/skeema/decks.sql
+++ b/app/db/skeema/decks.sql
@@ -9,7 +9,6 @@ CREATE TABLE `decks` (
   `easeMultiplier` float NOT NULL DEFAULT '2',
   `easeBonus` float NOT NULL DEFAULT '1.5',
   `randomMode` tinyint(1) NOT NULL DEFAULT '0',
-  `practiceEntriesCountByQueueType` json NOT NULL DEFAULT (json_object(_utf8mb4'NEW',0,_utf8mb4'LEARN',0,_utf8mb4'REVIEW',0)),
   `cache` json NOT NULL DEFAULT (json_object()),
   PRIMARY KEY (`id`),
   KEY `decks_userId_key` (`userId`)

--- a/app/db/skeema/decks.sql
+++ b/app/db/skeema/decks.sql
@@ -10,6 +10,7 @@ CREATE TABLE `decks` (
   `easeBonus` float NOT NULL DEFAULT '1.5',
   `randomMode` tinyint(1) NOT NULL DEFAULT '0',
   `practiceEntriesCountByQueueType` json NOT NULL DEFAULT (json_object(_utf8mb4'NEW',0,_utf8mb4'LEARN',0,_utf8mb4'REVIEW',0)),
+  `cache` json NOT NULL DEFAULT (json_object()),
   PRIMARY KEY (`id`),
   KEY `decks_userId_key` (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/app/db/types.ts
+++ b/app/db/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { defaultObject } from "../utils/misc";
 
 // cf. Anki's practice system
 // - https://docs.ankiweb.net/studying.html
@@ -17,3 +18,16 @@ export const PRACTICE_QUEUE_TYPES = Z_PRACTICE_QUEUE_TYPES.options;
 
 export type PracticeActionType = z.infer<typeof Z_PRACTICE_ACTION_TYPES>;
 export type PracticeQueueType = z.infer<typeof Z_PRACTICE_QUEUE_TYPES>;
+
+// prettier-ignore
+export interface DeckCache {
+  nextEntriesRandomMode: { id: number }[];
+  practiceEntriesCountByQueueType: Record<PracticeQueueType, number>;
+  practiceActionsCountByActionType: Record<PracticeActionType, number>;
+}
+
+export const DEFAULT_DECK_CACHE: DeckCache = {
+  nextEntriesRandomMode: [],
+  practiceEntriesCountByQueueType: defaultObject(PRACTICE_QUEUE_TYPES, 0),
+  practiceActionsCountByActionType: defaultObject(PRACTICE_ACTION_TYPES, 0),
+};

--- a/app/db/types.ts
+++ b/app/db/types.ts
@@ -19,7 +19,6 @@ export const PRACTICE_QUEUE_TYPES = Z_PRACTICE_QUEUE_TYPES.options;
 export type PracticeActionType = z.infer<typeof Z_PRACTICE_ACTION_TYPES>;
 export type PracticeQueueType = z.infer<typeof Z_PRACTICE_QUEUE_TYPES>;
 
-// prettier-ignore
 export interface DeckCache {
   nextEntriesRandomMode: { id: number }[];
   practiceEntriesCountByQueueType: Record<PracticeQueueType, number>;

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -1,6 +1,6 @@
 import { deepEqual } from "assert/strict";
 import fs from "node:fs";
-import { tinyassert } from "@hiogawa/utils";
+import { objectPick, tinyassert } from "@hiogawa/utils";
 import { cac } from "cac";
 import consola from "consola";
 import { range, zip } from "lodash";
@@ -24,6 +24,7 @@ import { exec, streamToString } from "../utils/node.server";
 import {
   queryDeckPracticeEntriesCountByQueueType,
   queryNextPracticeEntryRandomMode,
+  resetDeckCache,
 } from "../utils/practice-system";
 import { NewVideo, fetchCaptionEntries } from "../utils/youtube";
 import { finalizeServer, initializeServer } from "./initialize-server";
@@ -529,6 +530,21 @@ async function printSession(username: string, password: string) {
   const cookie = await createUserCookie(user);
   console.log(cookie);
 }
+
+//
+// resetDeckCache
+//
+
+cli.command(resetDeckCache.name).action(async () => {
+  const decks = await db.select().from(T.decks);
+  for (const deck of decks) {
+    console.log(
+      "::",
+      JSON.stringify(objectPick(deck, ["userId", "id", "name"]))
+    );
+    await resetDeckCache(deck.id);
+  }
+});
 
 //
 // main

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -22,7 +22,6 @@ import {
 } from "../utils/auth";
 import { exec, streamToString } from "../utils/node.server";
 import {
-  queryDeckPracticeEntriesCountByQueueType,
   queryNextPracticeEntryRandomMode,
   resetDeckCache,
 } from "../utils/practice-system";
@@ -511,18 +510,6 @@ cli
         .onConflict("id")
         .merge(["id", "practiceActionsCount", "updatedAt"]);
     });
-  });
-
-cli
-  .command("reset-counter-cache:decks.practiceEntriesCountByQueueType")
-  .action(async () => {
-    const ids = await Q.decks().pluck("id");
-    for (const id of ids) {
-      const result = await queryDeckPracticeEntriesCountByQueueType(id);
-      await Q.decks()
-        .where("id", id)
-        .update("practiceEntriesCountByQueueType", JSON.stringify(result));
-    }
   });
 
 async function printSession(username: string, password: string) {

--- a/app/misc/seed-utils.ts
+++ b/app/misc/seed-utils.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { UncheckedMap, objectOmit, tinyassert, uniq } from "@hiogawa/utils";
 import superjson from "superjson";
 import { E, T, db, findOne } from "../db/drizzle-client.server";
+import { DEFAULT_DECK_CACHE } from "../db/types";
 
 //
 // export/import all data associated to single deck
@@ -86,6 +87,7 @@ async function importDeck(userId: number, data: ExportDeckData) {
   const [deckInsert] = await db.insert(T.decks).values({
     ...objectOmit(deck, ["id"]),
     userId: user.id,
+    cache: DEFAULT_DECK_CACHE,
   });
 
   const [videoInsert] = await db.insert(T.videos).values(

--- a/app/misc/seed-utils.ts
+++ b/app/misc/seed-utils.ts
@@ -1,5 +1,11 @@
 import fs from "fs";
-import { UncheckedMap, objectOmit, tinyassert, uniq, range } from "@hiogawa/utils";
+import {
+  UncheckedMap,
+  objectOmit,
+  objectPick,
+  tinyassert,
+  uniq,
+} from "@hiogawa/utils";
 import superjson from "superjson";
 import { E, T, db, findOne } from "../db/drizzle-client.server";
 import { DEFAULT_DECK_CACHE } from "../db/types";
@@ -86,7 +92,16 @@ async function importDeck(userId: number, data: ExportDeckData) {
   } = data;
 
   const [deckInsert] = await db.insert(T.decks).values({
-    ...objectOmit(deck, ["id"]),
+    ...objectPick(deck, [
+      "createdAt",
+      "updatedAt",
+      "name",
+      "newEntriesPerDay",
+      "reviewsPerDay",
+      "easeMultiplier",
+      "easeBonus",
+      "randomMode",
+    ]),
     userId: user.id,
     cache: DEFAULT_DECK_CACHE,
   });
@@ -152,9 +167,7 @@ async function importDeck(userId: number, data: ExportDeckData) {
     practiceActions.map((e) => e.id)
   );
 
-  for (const i of range(deckInsert.affectedRows)) {
-    await resetDeckCache(deckInsert.insertId + i);
-  }
+  await resetDeckCache(deckInsert.insertId);
 
   return deckInsert.insertId;
 }

--- a/app/misc/seed-utils.ts
+++ b/app/misc/seed-utils.ts
@@ -1,8 +1,9 @@
 import fs from "fs";
-import { UncheckedMap, objectOmit, tinyassert, uniq } from "@hiogawa/utils";
+import { UncheckedMap, objectOmit, tinyassert, uniq, range } from "@hiogawa/utils";
 import superjson from "superjson";
 import { E, T, db, findOne } from "../db/drizzle-client.server";
 import { DEFAULT_DECK_CACHE } from "../db/types";
+import { resetDeckCache } from "../utils/practice-system";
 
 //
 // export/import all data associated to single deck
@@ -150,6 +151,10 @@ async function importDeck(userId: number, data: ExportDeckData) {
     practiceActionsInsert.insertId,
     practiceActions.map((e) => e.id)
   );
+
+  for (const i of range(deckInsert.affectedRows)) {
+    await resetDeckCache(deckInsert.insertId + i);
+  }
 
   return deckInsert.insertId;
 }

--- a/app/misc/seed-utils.ts
+++ b/app/misc/seed-utils.ts
@@ -93,8 +93,6 @@ async function importDeck(userId: number, data: ExportDeckData) {
 
   const [deckInsert] = await db.insert(T.decks).values({
     ...objectPick(deck, [
-      "createdAt",
-      "updatedAt",
       "name",
       "newEntriesPerDay",
       "reviewsPerDay",

--- a/app/routes/decks/$id/history.test.ts
+++ b/app/routes/decks/$id/history.test.ts
@@ -43,6 +43,7 @@ describe("decks/id/history.loader", () => {
       {
         "json": {
           "deck": {
+            "cache": {},
             "createdAt": "...",
             "easeBonus": 2,
             "easeMultiplier": 1.5,

--- a/app/routes/decks/$id/history.test.ts
+++ b/app/routes/decks/$id/history.test.ts
@@ -1,6 +1,7 @@
 import { tinyassert } from "@hiogawa/utils";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { E, T, db } from "../../../db/drizzle-client.server";
+import { DEFAULT_DECK_CACHE } from "../../../db/types";
 import { testLoader, useUser } from "../../../misc/test-helper";
 import { loader } from "./history";
 
@@ -19,6 +20,7 @@ describe("decks/id/history.loader", () => {
       easeMultiplier: 1.5,
       easeBonus: 2,
       userId: user.data.id,
+      cache: DEFAULT_DECK_CACHE,
     });
   });
 
@@ -43,7 +45,20 @@ describe("decks/id/history.loader", () => {
       {
         "json": {
           "deck": {
-            "cache": {},
+            "cache": {
+              "nextEntriesRandomMode": [],
+              "practiceActionsCountByActionType": {
+                "AGAIN": 0,
+                "EASY": 0,
+                "GOOD": 0,
+                "HARD": 0,
+              },
+              "practiceEntriesCountByQueueType": {
+                "LEARN": 0,
+                "NEW": 0,
+                "REVIEW": 0,
+              },
+            },
             "createdAt": "...",
             "easeBonus": 2,
             "easeMultiplier": 1.5,

--- a/app/routes/decks/$id/history.test.ts
+++ b/app/routes/decks/$id/history.test.ts
@@ -65,11 +65,6 @@ describe("decks/id/history.loader", () => {
             "id": "...",
             "name": "test",
             "newEntriesPerDay": 20,
-            "practiceEntriesCountByQueueType": {
-              "LEARN": 0,
-              "NEW": 0,
-              "REVIEW": 0,
-            },
             "randomMode": false,
             "reviewsPerDay": 200,
             "updatedAt": "...",

--- a/app/trpc/routes/decks.ts
+++ b/app/trpc/routes/decks.ts
@@ -6,7 +6,7 @@ import {
   PracticeHistoryChartDataEntry,
 } from "../../components/practice-history-chart";
 import { E, T, db, findOne } from "../../db/drizzle-client.server";
-import { Z_PRACTICE_ACTION_TYPES } from "../../db/types";
+import { DEFAULT_DECK_CACHE, Z_PRACTICE_ACTION_TYPES } from "../../db/types";
 import { importDeckJson } from "../../misc/seed-utils";
 import { PracticeSystem } from "../../utils/practice-system";
 import {
@@ -104,6 +104,7 @@ export const trpcRoutesDecks = {
       const [{ insertId: deckId }] = await db.insert(T.decks).values({
         ...input,
         userId: ctx.user.id,
+        cache: DEFAULT_DECK_CACHE,
       });
       return { deckId };
     }),

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -50,3 +50,26 @@ export function objectFromMap<K extends keyof any, V>(
   }
   return result;
 }
+
+// safely create non-Partial record by forcing providing complete keys (cf. https://github.com/colinhacks/zod/blob/502384e56fe2b1f8173735df6c3b0d41bce04edc/src/types.ts#L3946)
+export function objectFromMapDefault<
+  K extends string,
+  Keys extends [K, ...K[]],
+  V
+>(
+  map: Map<Keys[number], V>,
+  keys: Keys,
+  defaultValue: V
+): Record<Keys[number], V> {
+  return {
+    ...defaultObject(keys, defaultValue),
+    ...objectFromMap(map),
+  };
+}
+
+function defaultObject<K extends string, Keys extends [K, ...K[]], V>(
+  keys: Keys,
+  defaultValue: V
+): Record<Keys[number], V> {
+  return Object.fromEntries(keys.map((t) => [t, defaultValue])) as any;
+}

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -67,7 +67,7 @@ export function objectFromMapDefault<
   };
 }
 
-function defaultObject<K extends string, Keys extends [K, ...K[]], V>(
+export function defaultObject<K extends string, Keys extends [K, ...K[]], V>(
   keys: Keys,
   defaultValue: V
 ): Record<Keys[number], V> {

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -51,7 +51,7 @@ export function objectFromMap<K extends keyof any, V>(
   return result;
 }
 
-// safely create non-Partial record by forcing providing complete keys (cf. https://github.com/colinhacks/zod/blob/502384e56fe2b1f8173735df6c3b0d41bce04edc/src/types.ts#L3946)
+// safely create non-Partial record by forcing to provide complete keys (cf. https://github.com/colinhacks/zod/blob/502384e56fe2b1f8173735df6c3b0d41bce04edc/src/types.ts#L3946)
 export function objectFromMapDefault<
   K extends string,
   Keys extends [K, ...K[]],

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -44,5 +44,9 @@ export function mapGroupBy<T, K, V>(
 export function objectFromMap<K extends keyof any, V>(
   map: Map<K, V>
 ): Partial<Record<K, V>> {
-  return Object.fromEntries(map.entries()) as any;
+  const result: Partial<Record<K, V>> = {};
+  for (const [k, v] of map) {
+    result[k] = v;
+  }
+  return result;
 }

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -157,6 +157,7 @@ describe("randomMode", () => {
     const entries: TT["practiceEntries"][] = [];
     // loop practice N times
     const n = 100;
+    deck.updatedAt = NOW; // make randomMode deterministic
     for (const _ of range(n)) {
       const entry = await system.getNextPracticeEntry();
       tinyassert(entry);
@@ -171,9 +172,9 @@ describe("randomMode", () => {
     );
     expect(countMap).toMatchInlineSnapshot(`
       Map {
-        "NEW" => 88,
+        "NEW" => 93,
+        "LEARN" => 5,
         "REVIEW" => 2,
-        "LEARN" => 10,
       }
     `);
     // should pick mostly random practice entries

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -8,6 +8,7 @@ import {
   PracticeSystem,
   hashInt32,
   queryNextPracticeEntryRandomMode,
+  resetDeckCache,
 } from "./practice-system";
 
 // it doesn't matter yet but make NOW deterministic
@@ -218,6 +219,32 @@ describe("hashInt32", () => {
         100,
         90,
       ]
+    `);
+  });
+});
+
+describe(resetDeckCache.name, () => {
+  const userHook = useUser({
+    seed: __filename + "randomMode",
+  });
+  let deckId: number;
+
+  beforeAll(async () => {
+    await userHook.isReady;
+    deckId = await importSeed(userHook.data.id);
+  });
+
+  it("basic", async () => {
+    await resetDeckCache(deckId);
+    const deck = await findOne(
+      db.select().from(T.decks).where(E.eq(T.decks.id, deckId))
+    );
+    tinyassert(deck);
+    expect(deck.cache).toMatchInlineSnapshot(`
+      {
+        "practiceActionsCountByActionType": "{\\"HARD\\":64,\\"GOOD\\":55,\\"AGAIN\\":128}",
+        "practiceEntriesCountByQueueType": "{\\"REVIEW\\":13,\\"LEARN\\":187,\\"NEW\\":140}",
+      }
     `);
   });
 });

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -2,6 +2,7 @@ import { groupBy, mapValues, range, tinyassert, uniq } from "@hiogawa/utils";
 import { beforeAll, describe, expect, it } from "vitest";
 import { E, T, TT, db, findOne } from "../db/drizzle-client.server";
 import { Q } from "../db/models";
+import { DEFAULT_DECK_CACHE } from "../db/types";
 import { importSeed } from "../misc/seed-utils";
 import { useUser, useUserVideo } from "../misc/test-helper";
 import {
@@ -22,9 +23,10 @@ describe("PracticeSystem", () => {
 
   it("basic", async () => {
     // TODO: move to `use...` helpers
-    const [deckId] = await Q.decks().insert({
-      userId: hook.user.id,
+    const [{ insertId: deckId }] = await db.insert(T.decks).values({
       name: __filename,
+      userId: hook.user.id,
+      cache: DEFAULT_DECK_CACHE,
     });
     const deck = await Q.decks().where({ id: deckId }).first();
     tinyassert(deck);

--- a/app/utils/practice-system.ts
+++ b/app/utils/practice-system.ts
@@ -233,10 +233,22 @@ export class PracticeSystem {
       [newQueueType]: queueType !== newQueueType ? 1 : 0,
     });
 
+    const queryUpdateDeckV2 = updateDeckCache(
+      deckId,
+      {
+        [queueType]: queueType !== newQueueType ? -1 : 0,
+        [newQueueType]: queueType !== newQueueType ? 1 : 0,
+      },
+      {
+        [actionType]: 1,
+      }
+    );
+
     const [[{ insertId }]] = await Promise.all([
       queryCreatePracticeAction,
       queryUpdatePracticeEntry,
       queryUpdateDeck,
+      queryUpdateDeckV2,
     ]);
     return insertId;
   }


### PR DESCRIPTION
- required by https://github.com/hi-ogawa/ytsub-v3/pull/289
- a part of
  - https://github.com/hi-ogawa/ytsub-v3/issues/256
  - https://github.com/hi-ogawa/ytsub-v3/issues/208

## todo

- [x] reset cache logic
  - [x] cli
  - [x] initialize on deck creation
- [x] incremental update logic
- [x] depreacte old column
- [ ] ~two phase migration?~
  - [ ] add new column
  - [ ] deploy new app
  - [ ] remove old column
- [ ] migration (knex + cli)
  - [ ] staging
  - [ ] production
- [ ] (later) practice next entries caching