### PR TITLE
perf(db): reduce db read on /decks/id/history page

### DIFF
--- a/app/trpc/routes/decks.ts
+++ b/app/trpc/routes/decks.ts
@@ -333,6 +333,38 @@ export const trpcRoutesDecks = {
         daily,
       };
     }),
+
+  decks_practiceEntryDetail: procedureBuilder
+    .use(middlewares.requireUser)
+    .input(
+      z.object({
+        practiceEntryId: z.number().int(),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const row = await findOne(
+        db
+          .select()
+          .from(T.practiceEntries)
+          .innerJoin(
+            T.bookmarkEntries,
+            E.eq(T.bookmarkEntries.id, T.practiceEntries.bookmarkEntryId)
+          )
+          .innerJoin(
+            T.captionEntries,
+            E.eq(T.captionEntries.id, T.bookmarkEntries.captionEntryId)
+          )
+          .innerJoin(T.videos, E.eq(T.videos.id, T.captionEntries.videoId))
+          .where(
+            E.and(
+              E.eq(T.practiceEntries.id, input.practiceEntryId),
+              E.eq(T.bookmarkEntries.userId, ctx.user.id)
+            )
+          )
+      );
+      tinyassert(row);
+      return row;
+    }),
 };
 
 //


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/ytsub-v3/issues/305

## todo

- need `deckId, actionType, createdAt` index? (probably `deckdId, createdAt` should be enough)
- maybe make it infinite scroll