### PR TITLE
ci: pin skeema to silence lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
       - run: make db/reset/dev
       - name: install skeema
         run: |
-          curl -LO https://github.com/skeema/skeema/releases/latest/download/skeema_amd64.deb
+          # TODO: update to latest
+          curl -LO https://github.com/skeema/skeema/releases/v1.9.0/download/skeema_amd64.deb
           sudo apt install ./skeema_amd64.deb
       - run: pnpm skeema diff
       - run: pnpm skeema lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: install skeema
         run: |
           # TODO: update to latest
-          curl -LO https://github.com/skeema/skeema/releases/v1.9.0/download/skeema_amd64.deb
+          curl -LO https://github.com/skeema/skeema/releases/download/v1.9.0/skeema_amd64.deb
           sudo apt install ./skeema_amd64.deb
       - run: pnpm skeema diff
       - run: pnpm skeema lint


### PR DESCRIPTION
CI started to fail since skeema 1.10 due to `lint-reserved-word`
- https://github.com/skeema/skeema/releases/tag/v1.10.0

For now, we pin the old one as a quickest workaround.