### PR TITLE
refactor: simplify theme script injection?

### DIFF
--- a/app/components/theme-select.tsx
+++ b/app/components/theme-select.tsx
@@ -1,3 +1,4 @@
+import { tinyassert } from "@hiogawa/utils";
 import React from "react";
 import { capitalize } from "../utils/misc";
 import { SelectWrapper } from "./misc";
@@ -42,3 +43,25 @@ function useTheme() {
 
   return [theme, setThemeWrapper] as const;
 }
+
+export function injectThemeScript(markup: string): string {
+  // patch @remix/dev to use raw loader for ".html"
+  const indexHtml = require("../../index.html");
+  tinyassert(typeof indexHtml === "string");
+
+  const themeScript = indexHtml.match(/<script>(.*?)<\/script>/ms)?.[1];
+  tinyassert(themeScript);
+
+  return markup.replace(MARKER_ThemeScriptPlaceholder, themeScript);
+}
+
+export function ThemeScriptPlaceholder() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: MARKER_ThemeScriptPlaceholder }}
+      suppressHydrationWarning
+    />
+  );
+}
+
+const MARKER_ThemeScriptPlaceholder = "@@__ThemeScriptPlaceholder@@";

--- a/app/components/theme-select.tsx
+++ b/app/components/theme-select.tsx
@@ -46,10 +46,10 @@ function useTheme() {
 
 export function injectThemeScript(markup: string): string {
   // patch @remix/dev to use raw loader for ".html"
-  const indexHtml = require("../../index.html");
-  tinyassert(typeof indexHtml === "string");
+  const viteIndexHtml = require("../../index.html");
+  tinyassert(typeof viteIndexHtml === "string");
 
-  const themeScript = indexHtml.match(/<script>(.*?)<\/script>/ms)?.[1];
+  const themeScript = viteIndexHtml.match(/<script>(.*?)<\/script>/ms)?.[1];
   tinyassert(themeScript);
 
   return markup.replace(MARKER_ThemeScriptPlaceholder, themeScript);

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,7 @@
 import { RemixServer } from "@remix-run/react";
 import type { HandleDocumentRequestFunction } from "@remix-run/server-runtime";
 import { renderToString } from "react-dom/server";
+import { injectThemeScript } from "./components/theme-select";
 import { injectInitializeServer } from "./misc/initialize-server";
 import { injectConfigScript } from "./utils/config";
 
@@ -17,6 +18,7 @@ const handler: HandleDocumentRequestFunction = (
     <RemixServer context={remixContext} url={request.url} />
   );
   markup = injectConfigScript(markup);
+  markup = injectThemeScript(markup);
   responseHeaders.set("content-type", "text/html");
   return new Response("<!DOCTYPE html>" + markup, {
     status: responseStatusCode,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,7 @@ import { useForm } from "react-hook-form";
 import { Toaster } from "react-hot-toast";
 import { Drawer } from "./components/drawer";
 import { PopoverSimple } from "./components/popover";
-import { ThemeSelect } from "./components/theme-select";
+import { ThemeScriptPlaceholder, ThemeSelect } from "./components/theme-select";
 import { TopProgressBarRemix } from "./components/top-progress-bar";
 import type { UserTable } from "./db/models";
 import { $R, R } from "./misc/routes";
@@ -74,8 +74,8 @@ export default function DefaultComponent() {
         <Meta />
         <Links />
         <ConfigPlaceholder />
+        <ThemeScriptPlaceholder />
         <HideRecaptchaBadge />
-        <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }}></script>
       </head>
       <body className="h-full">
         {/* TODO: default position="top" is fine? */}
@@ -90,10 +90,6 @@ export default function DefaultComponent() {
     </html>
   );
 }
-
-// copied from index.html via
-//   node -e 'console.log(fs.readFileSync("./index.html", "utf-8").match(/<script>(.*?)<\/script>/sm)[1].replaceAll(/\/\/.*/g, "").replaceAll("\n", " ").trim())'
-const THEME_SCRIPT = `(() => {         const STORAGE_KEY = "ytsub:theme";         const DEFAULT_THEME = "system";         const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");          function getTheme() {           return window.localStorage.getItem(STORAGE_KEY) || DEFAULT_THEME;         }          function setTheme(config) {           window.localStorage.setItem(STORAGE_KEY, config);           applyTheme();         }          function applyTheme() {           const theme = getTheme();           const derived = theme === "system" ? (prefersDark.matches ? "dark" : "light") : theme;           disableTransitions(() => {             document.documentElement.classList.remove("dark", "light");             document.documentElement.classList.add(derived);           });         }                   function disableTransitions(callback) {           const el = document.createElement("style");           el.innerHTML = "* { transition: none !important; }";           document.head.appendChild(el);           callback();           window.getComputedStyle(document.documentElement).transition;            document.head.removeChild(el);         }          function initTheme() {           applyTheme();           prefersDark.addEventListener("change", applyTheme);           Object.assign(globalThis, { __theme: { setTheme, getTheme } });         }          initTheme();       })();`;
 
 function Root() {
   const data = useRootLoaderData();

--- a/patches/@remix-run__dev@1.15.0.patch
+++ b/patches/@remix-run__dev@1.15.0.patch
@@ -1,3 +1,15 @@
+diff --git a/dist/compiler/loaders.js b/dist/compiler/loaders.js
+index a3f7dc36d245afb8176208b0f75bbd03bdec4cfb..480cad0ceda075847f81c9c0cc3afe8ba0d0c595 100644
+--- a/dist/compiler/loaders.js
++++ b/dist/compiler/loaders.js
+@@ -35,6 +35,7 @@ function _interopNamespace(e) {
+ var path__namespace = /*#__PURE__*/_interopNamespace(path);
+
+ const loaders = {
++  ".html": "text",
+   ".aac": "file",
+   ".avif": "file",
+   ".css": "file",
 diff --git a/dist/config.js b/dist/config.js
 index 4127eef2a81df8ea28f6c71f3f98d614dd31ef46..76e6a8d0df63498a8a690af476d66072ff198e94 100644
 --- a/dist/config.js

--- a/patches/@remix-run__dev@1.15.0.patch
+++ b/patches/@remix-run__dev@1.15.0.patch
@@ -1,10 +1,10 @@
 diff --git a/dist/compiler/loaders.js b/dist/compiler/loaders.js
-index a3f7dc36d245afb8176208b0f75bbd03bdec4cfb..480cad0ceda075847f81c9c0cc3afe8ba0d0c595 100644
+index a3f7dc36d245afb8176208b0f75bbd03bdec4cfb..0d6a63e8408dac14b19734cb74de25830cd7168a 100644
 --- a/dist/compiler/loaders.js
 +++ b/dist/compiler/loaders.js
 @@ -35,6 +35,7 @@ function _interopNamespace(e) {
  var path__namespace = /*#__PURE__*/_interopNamespace(path);
-
+ 
  const loaders = {
 +  ".html": "text",
    ".aac": "file",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 patchedDependencies:
   '@remix-run/dev@1.15.0':
-    hash: rqfzo7n2m63btcgz53abqmb2he
+    hash: urofw2rnflbph2bcjlv53ot3sa
     path: patches/@remix-run__dev@1.15.0.patch
   '@remix-run/node@1.15.0':
     hash: z6mxtllsu73w4y6xnddlyl6j6y
@@ -133,7 +133,7 @@ devDependencies:
     version: 1.31.2
   '@remix-run/dev':
     specifier: 1.15.0
-    version: 1.15.0(patch_hash=rqfzo7n2m63btcgz53abqmb2he)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
+    version: 1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
   '@remix-run/serve':
     specifier: 1.15.0
     version: 1.15.0
@@ -2277,7 +2277,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@remix-run/dev@1.15.0(patch_hash=rqfzo7n2m63btcgz53abqmb2he)(@remix-run/serve@1.15.0)(@types/node@16.11.35):
+  /@remix-run/dev@1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35):
     resolution: {integrity: sha512-BsE1GN6WM9PhN+agZi4TqUIuYzoHYZrufEdXLg3ZEYxWXqvtRKUNfhsYSDlEhrW+D5fyVQhJrs61wQ83sEXHLQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -2428,7 +2428,7 @@ packages:
     peerDependencies:
       '@remix-run/dev': ^1.15.0
     dependencies:
-      '@remix-run/dev': 1.15.0(patch_hash=rqfzo7n2m63btcgz53abqmb2he)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
+      '@remix-run/dev': 1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
       minimatch: 7.4.6
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 patchedDependencies:
   '@remix-run/dev@1.15.0':
-    hash: urofw2rnflbph2bcjlv53ot3sa
+    hash: hrsihqxu4yrp7vj5ptkgtxrhv4
     path: patches/@remix-run__dev@1.15.0.patch
   '@remix-run/node@1.15.0':
     hash: z6mxtllsu73w4y6xnddlyl6j6y
@@ -133,7 +133,7 @@ devDependencies:
     version: 1.31.2
   '@remix-run/dev':
     specifier: 1.15.0
-    version: 1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
+    version: 1.15.0(patch_hash=hrsihqxu4yrp7vj5ptkgtxrhv4)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
   '@remix-run/serve':
     specifier: 1.15.0
     version: 1.15.0
@@ -2277,7 +2277,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@remix-run/dev@1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35):
+  /@remix-run/dev@1.15.0(patch_hash=hrsihqxu4yrp7vj5ptkgtxrhv4)(@remix-run/serve@1.15.0)(@types/node@16.11.35):
     resolution: {integrity: sha512-BsE1GN6WM9PhN+agZi4TqUIuYzoHYZrufEdXLg3ZEYxWXqvtRKUNfhsYSDlEhrW+D5fyVQhJrs61wQ83sEXHLQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -2428,7 +2428,7 @@ packages:
     peerDependencies:
       '@remix-run/dev': ^1.15.0
     dependencies:
-      '@remix-run/dev': 1.15.0(patch_hash=urofw2rnflbph2bcjlv53ot3sa)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
+      '@remix-run/dev': 1.15.0(patch_hash=hrsihqxu4yrp7vj5ptkgtxrhv4)(@remix-run/serve@1.15.0)(@types/node@16.11.35)
       minimatch: 7.4.6
     dev: false
 


### PR DESCRIPTION
Not sure if we can call it "simplify"...
Unfortunately remix/esbuild doesn't support `?raw` loader, so for now we just patch `@remix/dev` to load `.html` as string.
The "placeholder" idea is similar to:
- https://github.com/hi-ogawa/ytsub-v3/pull/172