### PR TITLE
chore: view mysql general log for dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ db/log/enable:
 db/log/disable:
 	docker-compose exec -T mysql mysql -uroot -ppassword -e "SET global general_log = 0;"
 
+db/console/dev:
+	docker-compose exec mysql mysql -uroot -ppassword ytsub_development
+
 #
 # docker
 #

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,15 @@ db/migrate/dev:
 db/migrate/test:
 	NODE_ENV=test pnpm knex migrate:latest
 
+db/log/view:
+	docker-compose exec mysql tail -f /var/lib/mysql/__general.log
+
+db/log/enable:
+	docker-compose exec -T mysql mysql -uroot -ppassword -e "SET global log_output = 'FILE'; SET global general_log_file='/var/lib/mysql/__general.log'; SET global general_log = 1;"
+
+db/log/disable:
+	docker-compose exec -T mysql mysql -uroot -ppassword -e "SET global general_log = 0;"
+
 #
 # docker
 #


### PR DESCRIPTION
It would help, for example, to quickly find a raw query to use for `EXPLAIN`.

## usage

```sh
$ make db/log/enable

$ make db/log/view
...
2023-05-01T04:04:43.843310Z         9 Query     select `bookmarkEntries`.`id`, `bookmarkEntries`.`userId`, `bookmarkEntries`.`videoId`, `bookmarkEntries`.`captionEntryId`, `bookmarkEntries`.`createdAt`, `bookmarkEntries`.`updatedAt`, `bookmarkEntries`.`text`, `bookmarkEntries`.`side`, `bookmarkEntries`.`offset`, `videos`.`id`, `videos`.`userId`, `videos`.`createdAt`, `videos`.`updatedAt`, `videos`.`videoId`, `videos`.`language1_id`, `videos`.`language2_id`, `videos`.`language1_translation`, `videos`.`language2_translation`, `videos`.`title`, `videos`.`author`, `videos`.`channelId`, `videos`.`bookmarkEntriesCount`, `captionEntries`.`id`, `captionEntries`.`videoId`, `captionEntries`.`createdAt`, `captionEntries`.`updatedAt`, `captionEntries`.`index`, `captionEntries`.`begin`, `captionEntries`.`end`, `captionEntries`.`text1`, `captionEntries`.`text2` from `bookmarkEntries` inner join `videos`  on `videos`.`id` = `bookmarkEntries`.`videoId` inner join `captionEntries`  on `captionEntries`.`id` = `bookmarkEntries`.`captionEntryId` where (`bookmarkEntries`.`userId` = 1) order by `bookmarkEntries`.`createdAt` desc limit 20
2023-05-01T04:04:43.852982Z         9 Query     select COUNT(0) from `bookmarkEntries` inner join `videos`  on `videos`.`id` = `bookmarkEntries`.`videoId` inner join `captionEntries`  on `captionEntries`.`id` = `bookmarkEntries`.`captionEntryId` where (`bookmarkEntries`.`userId` = 1) order by `bookmarkEntries`.`createdAt` desc

$ make db/log/disable
```