### PR TITLE
perf(db): add `bookmarkEntries_userId_createdAt_key`

### DIFF
--- a/app/db/migrations/20230501041818_bookmarkEntries_userId_createdAt_key.ts
+++ b/app/db/migrations/20230501041818_bookmarkEntries_userId_createdAt_key.ts
@@ -1,0 +1,9 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex) {
+  await knex.raw("ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_key`, ADD KEY `bookmarkEntries_userId_createdAt_key` (`userId`,`createdAt`)");
+}
+
+export async function down(knex: Knex) {
+  await knex.raw("ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_createdAt_key`, ADD KEY `bookmarkEntries_userId_key` (`userId`)");
+}

--- a/app/db/migrations/20230501041818_bookmarkEntries_userId_createdAt_key.ts
+++ b/app/db/migrations/20230501041818_bookmarkEntries_userId_createdAt_key.ts
@@ -1,9 +1,13 @@
 import type { Knex } from "knex";
 
 export async function up(knex: Knex) {
-  await knex.raw("ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_key`, ADD KEY `bookmarkEntries_userId_createdAt_key` (`userId`,`createdAt`)");
+  await knex.raw(
+    "ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_key`, ADD KEY `bookmarkEntries_userId_createdAt_key` (`userId`,`createdAt`)"
+  );
 }
 
 export async function down(knex: Knex) {
-  await knex.raw("ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_createdAt_key`, ADD KEY `bookmarkEntries_userId_key` (`userId`)");
+  await knex.raw(
+    "ALTER TABLE `bookmarkEntries` DROP KEY `bookmarkEntries_userId_createdAt_key`, ADD KEY `bookmarkEntries_userId_key` (`userId`)"
+  );
 }

--- a/app/db/skeema/README.md
+++ b/app/db/skeema/README.md
@@ -23,7 +23,7 @@ git stash
 # 5. diff for `down` knex migration
 pnpm skeema diff --allow-unsafe
 
-# 6. restore skeema/yyy.sql
+# 6. restore skeema/some-table.sql
 git stash pop
 ```
 

--- a/app/db/skeema/bookmarkEntries.sql
+++ b/app/db/skeema/bookmarkEntries.sql
@@ -9,7 +9,7 @@ CREATE TABLE `bookmarkEntries` (
   `videoId` bigint NOT NULL,
   `captionEntryId` bigint NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `bookmarkEntries_userId_key` (`userId`),
+  KEY `bookmarkEntries_userId_createdAt_key` (`userId`,`createdAt`),
   KEY `bookmarkEntries_videoId_key` (`videoId`),
   KEY `bookmarkEntries_captionEntryId_key` (`captionEntryId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
- a part of https://github.com/hi-ogawa/ytsub-v3/issues/333

Used in `/bookmarks/history-chart`.

```
mysql> explain select `id`, `userId`, `videoId`, `captionEntryId`, `createdAt`, `updatedAt`, `text`, `side`, `offset` from `bookmarkEntries` where (`bookmarkEntries`.`userId` = 1 and `bookmarkEntries`.`createdAt` > '2023-03-20T00:00:00' and `bookmarkEntries`.`createdAt` < '2023-03-27T00:00:00');
+----+-------------+-----------------+------------+-------+--------------------------------------+--------------------------------------+---------+------+------+----------+-----------------------+
| id | select_type | table           | partitions | type  | possible_keys                        | key                                  | key_len | ref  | rows | filtered | Extra                 |
+----+-------------+-----------------+------------+-------+--------------------------------------+--------------------------------------+---------+------+------+----------+-----------------------+
|  1 | SIMPLE      | bookmarkEntries | NULL       | range | bookmarkEntries_userId_createdAt_key | bookmarkEntries_userId_createdAt_key | 13      | NULL |  107 |   100.00 | Using index condition |
+----+-------------+-----------------+------------+-------+--------------------------------------+--------------------------------------+---------+------+------+----------+-----------------------+
1 row in set, 1 warning (0.00 sec)
```

## todo

- [x] migration

```
pnpm knex-staging migrate:up

pnpm knex-production migrate:up
```