### PR TITLE
fix: avoid video deletion with associated practice entries

### DIFF
--- a/app/routes/videos/index.tsx
+++ b/app/routes/videos/index.tsx
@@ -127,8 +127,8 @@ function VideoComponentExtra({
       toast.success("Successfully deleted a video");
       navigate(R["/videos"]); // refetch
     },
-    onError: () => {
-      toast.error("Failed to delete a video");
+    onError: (e) => {
+      toast.error(e instanceof Error ? e.message : "Failed to delete a video");
     },
   });
   const modal = useModal();

--- a/app/trpc/routes/videos.ts
+++ b/app/trpc/routes/videos.ts
@@ -39,10 +39,21 @@ export const trpcRoutesVideos = {
       );
       tinyassert(video);
 
+      // TODO: support deleting videos with associated bookmarkEntries and practiceEntries
+      const found = await findOne(
+        db
+          .select()
+          .from(T.bookmarkEntries)
+          .where(E.eq(T.bookmarkEntries.videoId, id))
+      );
+      tinyassert(
+        !found,
+        "You cannot delete videos when you have associated bookmarks."
+      );
+
       await Promise.all([
         db.delete(T.videos).where(E.eq(T.videos.id, id)),
         db.delete(T.captionEntries).where(E.eq(T.captionEntries.videoId, id)),
-        db.delete(T.bookmarkEntries).where(E.eq(T.bookmarkEntries.videoId, id)),
       ]);
     }),
 

--- a/app/trpc/routes/videos.ts
+++ b/app/trpc/routes/videos.ts
@@ -48,7 +48,7 @@ export const trpcRoutesVideos = {
       );
       tinyassert(
         !found,
-        "You cannot delete videos when you have associated bookmarks."
+        "You cannot delete a video when it has associated bookmarks."
       );
 
       await Promise.all([


### PR DESCRIPTION
Some code breaks when there's orphan `practiceEntries`, so let's avoid that by throwing an error for now.
To be implemented in
- https://github.com/hi-ogawa/ytsub-v3/issues/20