### PR TITLE
chore: add request.headers to /dev/debug

### DIFF
--- a/app/routes/dev/debug.tsx
+++ b/app/routes/dev/debug.tsx
@@ -1,8 +1,17 @@
 import type { LoaderFunction } from "@remix-run/server-runtime";
 
-export const loader: LoaderFunction = async () => {
+export const loader: LoaderFunction = async ({ request }) => {
   return {
+    "request.headers": headersEntries(request.headers),
     "process.versions": process.versions,
     VERCEL_ENV: process.env.VERCEL_ENV,
   };
 };
+
+function headersEntries(headers: Headers) {
+  const entries: [string, string][] = [];
+  headers.forEach((v, k) => {
+    entries.push([k, v]);
+  });
+  return entries;
+}


### PR DESCRIPTION
For https://github.com/hi-ogawa/ytsub-v3/pull/337, I was curious what vercel/aws-lambda puts in `x-forwarded-???` headers.

```sh
$ curl -s https://ytsub-v3-hiro18181-hiogawa.vercel.app/dev/debug | jq -c '.["request.headers"] | .[]'
["accept","*/*"]
["connection","close"]
["forwarded","for=36.13.100.141;host=ytsub-v3-hiro18181-hiogawa.vercel.app;proto=https;sig=0QmVhcmVyIDg0NGNjMThlNjVkMDc3MmI5MmQ2M2IzMjY1Zjg3MDg5YjllYmVhNGI5OGE0M2FkNzUwMmRlYTEyNmJiOWY1NDc=;exp=1682937068"]
["host","ytsub-v3-hiro18181-hiogawa.vercel.app"]
["user-agent","curl/8.0.1"]
["x-forwarded-for","36.13.100.141"]
["x-forwarded-host","ytsub-v3-hiro18181-hiogawa.vercel.app"]
["x-forwarded-proto","https"]
["x-real-ip","36.13.100.141"]
["x-vercel-deployment-url","ytsub-v3-hiro18181-ixzb64l75-hiogawa.vercel.app"]
["x-vercel-forwarded-for","36.13.100.141"]
["x-vercel-id","hnd1::8pfmm-1682936768012-55f614ccd78f"]
["x-vercel-ip-city","Yokohama"]
["x-vercel-ip-country","JP"]
["x-vercel-ip-country-region","14"]
["x-vercel-ip-latitude","35.4343"]
["x-vercel-ip-longitude","139.6466"]
["x-vercel-ip-timezone","Asia/Tokyo"]
["x-vercel-proxied-for","36.13.100.141"]
["x-vercel-proxy-signature","Bearer 844cc18e65d0772b92d63b3265f87089b9ebea4b98a43ad7502dea126bb9f547"]
["x-vercel-proxy-signature-ts","1682937068"]
```