### PR TITLE
feat: highlight bookmarks in subtitle list

### DIFF
--- a/app/e2e/videos.test.ts
+++ b/app/e2e/videos.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import { E, T, db } from "../db/drizzle-client.server";
 import { importSeed } from "../misc/seed-utils";
-import { reTemplate } from "../utils/misc";
+import { regExpRaw } from "../utils/misc";
 import { test } from "./coverage";
 import { useUserE2E } from "./helper";
 
@@ -33,7 +33,7 @@ test.describe("videos-signed-in", () => {
     //
     // play video in "/videos/$id"
     //
-    await page.waitForURL(reTemplate`/videos/\d+$`);
+    await page.waitForURL(regExpRaw`/videos/\d+$`);
 
     // select text
     await page.getByText("잠깐 밖으로 나올래").evaluate((el) => {
@@ -103,7 +103,7 @@ test.describe("videos-signed-in", () => {
     await page.locator('[data-test="caption-entry-component__video-link"]').click();
 
     // back to the video
-    await page.waitForURL(reTemplate`/videos/\d+\?index=1$`);
+    await page.waitForURL(regExpRaw`/videos/\d+\?index=1$`);
   });
 });
 

--- a/app/e2e/videos.test.ts
+++ b/app/e2e/videos.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 import { E, T, db } from "../db/drizzle-client.server";
 import { importSeed } from "../misc/seed-utils";
+import { reTemplate } from "../utils/misc";
 import { test } from "./coverage";
 import { useUserE2E } from "./helper";
 
@@ -9,83 +10,100 @@ test.describe("videos-signed-in", () => {
     seed: __filename + "/users/me",
   });
 
-  test("new-video => show-video => new-bookmark => list-bookmarks", async ({
-    page,
-  }) => {
+  // prettier-ignore
+  test("create-bookmarks", async ({ page }) => {
     await user.signin(page);
 
     //
-    // navigate to /videos/new to create https://www.youtube.com/watch?v=EnPYXckiUVg with fr/en
+    // input video url in "/"
     //
-
-    await page.goto("/videos/new?videoId=EnPYXckiUVg");
-    await page
-      .locator("data-test=setup-form >> select >> nth=0")
-      .selectOption('{"id":".fr"}');
-    await page
-      .locator("data-test=setup-form >> select >> nth=1")
-      .selectOption('{"id":".en"}');
-    await page.locator('data-test=setup-form >> button[type="submit"]').click();
+    await page.goto("/");
+    await page.getByTestId("Navbar-drawer-button").click();
+    await page.getByPlaceholder("Enter Video ID or URL").fill("https://www.youtube.com/watch?v=4gXmClk8rKI");
+    await page.getByPlaceholder("Enter Video ID or URL").press("Enter");
 
     //
-    // navigate to /videos/$id
+    // create video in "/videos/new"
     //
+    await page.waitForURL("/videos/new?videoId=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D4gXmClk8rKI");
+    await page.getByRole("combobox", { name: "1st language" }).selectOption('{"id":".ko"}');
+    await page.getByRole("combobox", { name: "2nd language" }).selectOption('{"id":".en"}');
+    await page.getByRole("button", { name: "Save and Play" }).click();
 
-    await page.waitForSelector(`"Created a new video"`);
+    //
+    // play video in "/videos/$id"
+    //
+    await page.waitForURL(reTemplate`/videos/\d+$`);
 
-    await expect(page).toHaveURL(/\/videos\/\d+$/);
-
-    // select text to bookmark
-    const bookmarkable = page.locator(".--bookmarkable-- >> nth=6");
-    await bookmarkable.evaluate((el) => {
-      const text = el.childNodes[0];
+    // select text
+    await page.getByText("잠깐 밖으로 나올래").evaluate((el) => {
       const selection = window.getSelection();
-      const range = document.createRange();
-      range.setStart(text, 13);
-      range.setEnd(text, 39);
-      if (!selection) throw new Error();
-      selection.addRange(range);
+      selection?.setBaseAndExtent(el.childNodes[0], 0, el.childNodes[0], 6);
     });
 
-    // click bookmark
-    await page.locator("data-test=new-bookmark-button").click();
+    // create bookmark
+    await page.locator('[data-test="new-bookmark-button"]').click();
+    await page.getByText("Bookmark success").click();
 
-    // see success message
-    await page.waitForSelector(`"Bookmark success"`);
+    // highlight bookmarks
+    await page.getByTestId('video-menu-reference').click();
+    await page.getByRole('button', { name: 'Show bookmarks' }).click();
+    await expect(page.getByText('잠깐 밖으로')).toHaveAttribute("data-offset", "0");
+    await expect(page.getByText('잠깐 밖으로')).toHaveClass("text-colorPrimaryText")
+    await expect(page.getByText('나올래')).toHaveAttribute("data-offset", "6");
+    await expect(page.getByText('나올래')).not.toHaveClass("text-colorPrimaryText");
 
-    // verify database
+    // create overlapped bookmark
+    await page.getByText("잠깐 밖으로 나올래").evaluate((el) => {
+      const selection = window.getSelection();
+      selection?.setBaseAndExtent(el.childNodes[0].childNodes[0], 3, el.childNodes[1].childNodes[0], 3);
+    });
+    await page.getByTestId("toast-remove").evaluate((el: any) => el.click());
+    await page.locator('[data-test="new-bookmark-button"]').click();
+    await page.getByText("Bookmark success").click();
+
+    await page.getByText("잠깐 밖으로 나올래").evaluate((el) => {
+      const selection = window.getSelection();
+      selection?.setBaseAndExtent(el.childNodes[1].childNodes[0], 2, el.childNodes[3].childNodes[0], 1);
+    });
+    await page.getByTestId("toast-remove").evaluate((el: any) => el.click());
+    await page.locator('[data-test="new-bookmark-button"]').click();
+    await page.getByText("Bookmark success").click();
+
+    // check db
     const rows = await db
       .select()
       .from(T.bookmarkEntries)
       .where(E.eq(T.bookmarkEntries.userId, user.data.id));
-    expect(rows[0]).toMatchObject({
-      text: "qu'est-ce qu'on va faire ?",
-      offset: 13,
-      side: 0,
-    });
+    expect(rows).toMatchObject([
+      {
+        side: 0,
+        offset: 0,
+        text: "잠깐 밖으로",
+      },
+      {
+        side: 0,
+        offset: 3,
+        text: "밖으로 나올",
+      },
+      {
+        side: 0,
+        offset: 5,
+        text: "로 나올래",
+      },
+    ]);
 
     //
-    // navigate to bookmark list
+    // check created bookmarks in /bookmarks
     //
 
-    await page.goto("/bookmarks");
+    await page.getByTestId('Navbar-drawer-button').click();
+    await page.getByRole('link', { name: 'Bookmarks' }).click();
+    await page.getByText('잠깐 밖으로').click();
+    await page.locator('[data-test="caption-entry-component__video-link"]').click();
 
-    // verify bookmark text
-    await expect(
-      page.locator("data-test=bookmark-entry >> data-test=bookmark-entry-text")
-    ).toHaveText("qu'est-ce qu'on va faire ?");
-
-    // click "ChevronDown"
-    await page.locator("data-test=bookmark-entry >> button >> nth=0").click();
-
-    // click link to navigate back to /videos/$id
-    await page
-      .locator(
-        "data-test=bookmark-entry >> data-test=caption-entry-component__video-link >> nth=0"
-      )
-      .click();
-
-    await expect(page).toHaveURL(/\/videos\/\d+\?index=\d+$/);
+    // back to the video
+    await page.waitForURL(reTemplate`/videos/\d+\?index=1$`);
   });
 });
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,7 +14,7 @@ import type { LinksFunction } from "@remix-run/server-runtime";
 import { useMutation } from "@tanstack/react-query";
 import React from "react";
 import { useForm } from "react-hook-form";
-import { Toaster } from "react-hot-toast";
+import { Toaster, toast } from "react-hot-toast";
 import { Drawer } from "./components/drawer";
 import { PopoverSimple } from "./components/popover";
 import { ThemeScriptPlaceholder, ThemeSelect } from "./components/theme-select";
@@ -82,6 +82,13 @@ export default function DefaultComponent() {
           position="bottom-left"
           toastOptions={{
             className: "!bg-colorBgElevated !text-colorText",
+          }}
+        />
+        <button
+          className="hidden"
+          data-testid="toast-remove"
+          onClick={() => {
+            toast.remove();
           }}
         />
         <Compose elements={[<QueryClientWrapper />, <Root />]} />

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -366,13 +366,15 @@ export function MiniPlayer({
         <CaptionEntryComponent
           key={captionEntry.id}
           entry={captionEntry}
-          bookmarkEntries={bookmarkEntries}
           currentEntry={currentEntry}
           repeatingEntries={repeatingEntries}
           onClickEntryPlay={onClickEntryPlay}
           onClickEntryRepeat={toArraySetState(setRepeatingEntries).toggle}
           isPlaying={isPlaying}
           videoId={video.id}
+          bookmarkEntries={
+            captionEntry === initialEntry ? bookmarkEntries : undefined
+          }
           isFocused={captionEntry === initialEntry}
         />
       ))}

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -190,13 +190,9 @@ export function BookmarkEntryComponent({
         <MiniPlayer
           video={video}
           captionEntry={captionEntry}
+          bookmarkEntries={[bookmarkEntry]}
           autoplay={autoplay}
           defaultIsRepeating={autoplay}
-          highlight={{
-            side: bookmarkEntry.side,
-            offset: bookmarkEntry.offset,
-            length: bookmarkEntry.text.length,
-          }}
         />
       </CollapseTransition>
     </div>
@@ -207,15 +203,15 @@ export function BookmarkEntryComponent({
 export function MiniPlayer({
   video,
   captionEntry: initialEntry,
+  bookmarkEntries,
   autoplay,
   defaultIsRepeating,
-  highlight,
 }: {
   video: VideoTable;
   captionEntry: CaptionEntryTable;
+  bookmarkEntries?: TT["bookmarkEntries"][];
   autoplay: boolean;
   defaultIsRepeating: boolean;
-  highlight: { side: number; offset: number; length: number };
 }) {
   const [player, setPlayer] = React.useState<YoutubePlayer>();
   const [isPlaying, setIsPlaying] = React.useState(false);
@@ -370,13 +366,13 @@ export function MiniPlayer({
         <CaptionEntryComponent
           key={captionEntry.id}
           entry={captionEntry}
+          bookmarkEntries={bookmarkEntries}
           currentEntry={currentEntry}
           repeatingEntries={repeatingEntries}
           onClickEntryPlay={onClickEntryPlay}
           onClickEntryRepeat={toArraySetState(setRepeatingEntries).toggle}
           isPlaying={isPlaying}
           videoId={video.id}
-          highlight={captionEntry === initialEntry ? highlight : undefined}
           isFocused={captionEntry === initialEntry}
         />
       ))}

--- a/app/routes/decks/$id/history.tsx
+++ b/app/routes/decks/$id/history.tsx
@@ -257,13 +257,9 @@ function PracticeActionComponent(
           <MiniPlayer
             video={props.videos}
             captionEntry={props.captionEntries}
+            bookmarkEntries={[props.bookmarkEntries]}
             autoplay={autoplay}
             defaultIsRepeating={true}
-            highlight={{
-              side: props.bookmarkEntries.side,
-              offset: props.bookmarkEntries.offset,
-              length: props.bookmarkEntries.text.length,
-            }}
           />
         </div>
       </CollapseTransition>

--- a/app/routes/decks/$id/index.tsx
+++ b/app/routes/decks/$id/index.tsx
@@ -263,13 +263,9 @@ function PracticeBookmarkEntryComponent({
         <MiniPlayer
           video={video}
           captionEntry={captionEntry}
+          bookmarkEntries={[bookmarkEntry]}
           autoplay={false}
           defaultIsRepeating={false}
-          highlight={{
-            side: bookmarkEntry.side,
-            offset: bookmarkEntry.offset,
-            length: bookmarkEntry.text.length,
-          }}
         />
       )}
     </div>

--- a/app/routes/videos/$id.test.ts
+++ b/app/routes/videos/$id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { partitionRanges } from "./$id";
+
+describe(partitionRanges.name, () => {
+  it("basic", async () => {
+    expect(
+      partitionRanges(27, [
+        [12, 20],
+        [4, 10],
+      ])
+        .flat()
+        .join(" ")
+    ).toMatchInlineSnapshot(
+      '"false 0,4 true 4,10 false 10,12 true 12,20 false 20,27"'
+    );
+
+    expect(
+      partitionRanges(27, [
+        [4, 10],
+        [8, 12],
+      ])
+        .flat()
+        .join(" ")
+    ).toMatchInlineSnapshot(
+      '"false 0,4 true 4,8 true 8,10 true 10,12 false 12,27"'
+    );
+  });
+});

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -322,7 +322,10 @@ function PageComponent({
             />
           )}
           <Transition
-            show={captionEntriesQuery.isLoading}
+            show={
+              captionEntriesQuery.isLoading ||
+              bookmarkEntriesQuery.isInitialLoading
+            }
             className="duration-500 antd-body antd-spin-overlay-10"
             {...transitionProps("opacity-0", "opacity-50")}
           />

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -3,7 +3,12 @@ import { groupBy, sortBy, tinyassert, uniq } from "@hiogawa/utils";
 import { isNil } from "@hiogawa/utils";
 import { toArraySetState, useRafLoop } from "@hiogawa/utils-react";
 import { Link, useNavigate } from "@remix-run/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useIsFetching,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   VirtualItem,
   Virtualizer,
@@ -722,9 +727,6 @@ function NavBarMenuComponent() {
   const { video } = useLeafLoaderData() as LoaderData;
   const [autoScrollState, toggleAutoScrollState] = useAutoScrollState();
   const [repeatingEntries, setRepeatingEntries] = useRepeatingEntries();
-  const [highlightBookmark, setHighlightBookmark] = useAtom(
-    highlightBookmarkStorageAtom
-  );
   const modal = useModal();
 
   const navigate = useNavigate();
@@ -745,6 +747,13 @@ function NavBarMenuComponent() {
         toast.error("No bookmark is found");
       }
     },
+  });
+
+  const [highlightBookmark, setHighlightBookmark] = useAtom(
+    highlightBookmarkStorageAtom
+  );
+  const isFetchingBookmarkEntries = useIsFetching({
+    queryKey: [trpc.videos_getBookmarkEntries.queryKey],
   });
 
   return (
@@ -776,7 +785,14 @@ function NavBarMenuComponent() {
                 >
                   Show bookmarks
                   {highlightBookmark && (
-                    <span className="i-ri-check-line w-5 h-5"></span>
+                    <span
+                      className={cls(
+                        "w-5 h-5",
+                        isFetchingBookmarkEntries
+                          ? "antd-spin"
+                          : "i-ri-check-line"
+                      )}
+                    ></span>
                   )}
                 </button>
               </li>

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -3,12 +3,7 @@ import { groupBy, sortBy, tinyassert, uniq } from "@hiogawa/utils";
 import { isNil } from "@hiogawa/utils";
 import { toArraySetState, useRafLoop } from "@hiogawa/utils-react";
 import { Link, useNavigate } from "@remix-run/react";
-import {
-  useIsFetching,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   VirtualItem,
   Virtualizer,
@@ -727,6 +722,9 @@ function NavBarMenuComponent() {
   const { video } = useLeafLoaderData() as LoaderData;
   const [autoScrollState, toggleAutoScrollState] = useAutoScrollState();
   const [repeatingEntries, setRepeatingEntries] = useRepeatingEntries();
+  const [highlightBookmark, setHighlightBookmark] = useAtom(
+    highlightBookmarkStorageAtom
+  );
   const modal = useModal();
 
   const navigate = useNavigate();
@@ -747,13 +745,6 @@ function NavBarMenuComponent() {
         toast.error("No bookmark is found");
       }
     },
-  });
-
-  const [highlightBookmark, setHighlightBookmark] = useAtom(
-    highlightBookmarkStorageAtom
-  );
-  const isFetchingBookmarkEntries = useIsFetching({
-    queryKey: [trpc.videos_getBookmarkEntries.queryKey],
   });
 
   return (
@@ -785,14 +776,7 @@ function NavBarMenuComponent() {
                 >
                   Show bookmarks
                   {highlightBookmark && (
-                    <span
-                      className={cls(
-                        "w-5 h-5",
-                        isFetchingBookmarkEntries
-                          ? "antd-spin"
-                          : "i-ri-check-line"
-                      )}
-                    ></span>
+                    <span className="i-ri-check-line w-5 h-5"></span>
                   )}
                 </button>
               </li>

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -727,7 +727,7 @@ function NavBarMenuComponent() {
             />
           }
           floating={(context) => (
-            <ul className="flex flex-col gap-2 p-2 w-[200px] text-sm">
+            <ul className="flex flex-col gap-2 p-2 w-[190px] text-sm">
               <li>
                 <button
                   className="w-full antd-menu-item p-2 flex"
@@ -742,7 +742,7 @@ function NavBarMenuComponent() {
                   disabled={!currentUser}
                   onClick={() => setHighlightBookmark((prev) => !prev)}
                 >
-                  Highlight bookmarks
+                  Show bookmarks
                   {highlightBookmark && (
                     <span className="i-ri-check-line w-5 h-5"></span>
                   )}

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -665,7 +665,6 @@ const BOOKMARK_DATA_ATTR = z.enum([
 ]).enum;
 
 // desperate DOM manipulation to find selected data for new bookmark creation
-// TODO: make type-safe data attributes
 function extractBookmarkSelection(
   selection: Selection
 ): BookmarkSelection | undefined {

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -701,7 +701,6 @@ function extractBookmarkSelection(
   // check "data-index" element
   const dataIndexEl = dataSideEl.parentElement?.parentElement;
   const dataIndex = dataIndexEl?.getAttribute(BOOKMARK_DATA_ATTR["data-index"]);
-  console.log({ startEl, endEl, dataSideEl, dataIndexEl });
   if (!dataIndexEl || !dataIndex) return;
 
   return {

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -521,7 +521,6 @@ function CaptionEntriesComponent({
     const entry = entries[item.index];
 
     // TODO: merge multiple bookmarks under single caption entry?
-    // TODO: better highlight style? (not just underline)
     const bookmarkEntry = bookmarkEntryMap.get(entry.id)?.at(0);
 
     return (
@@ -533,6 +532,7 @@ function CaptionEntriesComponent({
             side: bookmarkEntry.side,
             offset: bookmarkEntry.offset,
             length: bookmarkEntry.text.length,
+            className: "text-colorPrimaryText",
           }
         }
         isFocused={focusedIndex === item.index}
@@ -570,7 +570,12 @@ export function CaptionEntryComponent({
   isFocused?: boolean;
   videoId?: number;
   border?: boolean;
-  highlight?: { side: number; offset: number; length: number };
+  highlight?: {
+    side: number;
+    offset: number;
+    length: number;
+    className?: string;
+  };
   // virtualized list
   virtualizer?: Virtualizer<HTMLDivElement, Element>;
   virtualItem?: VirtualItem;
@@ -642,6 +647,7 @@ export function CaptionEntryComponent({
               text={text1}
               offset={highlight.offset}
               length={highlight.length}
+              className={highlight.className}
             />
           ) : (
             text1
@@ -653,6 +659,7 @@ export function CaptionEntryComponent({
               text={text2}
               offset={highlight.offset}
               length={highlight.length}
+              className={highlight.className}
             />
           ) : (
             text2
@@ -667,10 +674,12 @@ function HighlightText({
   text,
   offset,
   length,
+  className,
 }: {
   text: string;
   offset: number;
   length: number;
+  className?: string;
 }) {
   const t1 = text.slice(0, offset);
   const t2 = text.slice(offset, offset + length);
@@ -678,7 +687,9 @@ function HighlightText({
   return (
     <>
       {t1}
-      <span className="border-b border-colorTextSecondary">{t2}</span>
+      <span className={className ?? "border-b border-colorTextSecondary"}>
+        {t2}
+      </span>
       {t3}
     </>
   );

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -727,7 +727,7 @@ function NavBarMenuComponent() {
             />
           }
           floating={(context) => (
-            <ul className="flex flex-col gap-2 p-2 w-[190px] text-sm">
+            <ul className="flex flex-col gap-2 p-2 w-[180px] text-sm">
               <li>
                 <button
                   className="w-full antd-menu-item p-2 flex"

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -148,11 +148,13 @@ function PageComponent({
     onSuccess: (newBookmark) => {
       toast.success("Bookmark success");
 
-      // mutate query cache instead of refetch
-      queryClient.setQueryData(bookmarkEntriesQueryOptions.queryKey, (prev) => [
-        ...(prev as TT["bookmarkEntries"][]),
-        newBookmark,
-      ]);
+      if (highlightBookmarkEnabled) {
+        // mutate query cache instead of refetch
+        queryClient.setQueryData(
+          bookmarkEntriesQueryOptions.queryKey,
+          (prev) => [...(prev as TT["bookmarkEntries"][]), newBookmark]
+        );
+      }
     },
     onError: () => {
       toast.error("Bookmark failed");

--- a/app/routes/videos/$id.tsx
+++ b/app/routes/videos/$id.tsx
@@ -614,7 +614,45 @@ export function CaptionEntryComponent({
   );
 }
 
-// ad-hoc DOM manipulation to find selected data for new bookmark creation
+function HighlightText({
+  text,
+  highlights,
+}: {
+  text: string;
+  highlights: { offset: number; text: string }[];
+}) {
+  const partitions = partitionRanges(
+    text.length,
+    highlights.map((h) => [h.offset, h.offset + h.text.length])
+  );
+  return (
+    <>
+      {partitions.map(([highlight, [start, end]]) => (
+        <span
+          key={start}
+          data-offset={start}
+          className={cls(highlight && "text-colorPrimaryText")}
+        >
+          {text.slice(start, end)}
+        </span>
+      ))}
+    </>
+  );
+}
+
+// export for testing
+export function partitionRanges(
+  total: number,
+  ranges: [number, number][]
+): [boolean, [number, number]][] {
+  const boundaries = uniq(sortBy(ranges.flat().concat([0, total]), (x) => x));
+  return zip(boundaries, boundaries.slice(1)).map((a) => [
+    ranges.some((b) => b[0] <= a[0] && a[1] <= b[1]),
+    a,
+  ]);
+}
+
+// desperate DOM manipulation to find selected data for new bookmark creation
 // TODO: make type-safe data attributes
 function extractBookmarkSelection(
   selection: Selection
@@ -663,42 +701,9 @@ function extractBookmarkSelection(
   };
 }
 
-function HighlightText({
-  text,
-  highlights,
-}: {
-  text: string;
-  highlights: { offset: number; text: string }[];
-}) {
-  const partitions = partitionRanges(
-    text.length,
-    highlights.map((h) => [h.offset, h.offset + h.text.length])
-  );
-  return (
-    <>
-      {partitions.map(([highlight, [start, end]]) => (
-        <span
-          key={start}
-          data-offset={start}
-          className={cls(highlight && "text-colorPrimaryText")}
-        >
-          {text.slice(start, end)}
-        </span>
-      ))}
-    </>
-  );
-}
-
-export function partitionRanges(
-  total: number,
-  ranges: [number, number][]
-): [boolean, [number, number]][] {
-  const boundaries = uniq(sortBy(ranges.flat().concat([0, total]), (x) => x));
-  return zip(boundaries, boundaries.slice(1)).map((a) => [
-    ranges.some((b) => b[0] <= a[0] && a[1] <= b[1]),
-    a,
-  ]);
-}
+//
+// NavBarMenuComponent
+//
 
 function NavBarMenuComponent() {
   const { currentUser } = useRootLoaderData();

--- a/app/trpc/routes/bookmarks.ts
+++ b/app/trpc/routes/bookmarks.ts
@@ -40,7 +40,7 @@ export const trpcRoutesBookmarks = {
       tinyassert(found, "not found");
 
       // insert with counter cache increment
-      await db.insert(T.bookmarkEntries).values({
+      const [{ insertId }] = await db.insert(T.bookmarkEntries).values({
         ...input,
         userId: ctx.user.id,
       });
@@ -50,6 +50,15 @@ export const trpcRoutesBookmarks = {
           bookmarkEntriesCount: sql`${T.videos.bookmarkEntriesCount} + 1`,
         })
         .where(E.eq(T.videos.id, input.videoId));
+
+      const row = await findOne(
+        db
+          .select()
+          .from(T.bookmarkEntries)
+          .where(E.eq(T.bookmarkEntries.id, insertId))
+      );
+      tinyassert(row);
+      return row;
     }),
 
   bookmarks_historyChart: procedureBuilder

--- a/app/trpc/routes/bookmarks.ts
+++ b/app/trpc/routes/bookmarks.ts
@@ -19,7 +19,7 @@ export const trpcRoutesBookmarks = {
         videoId: z.number().int(),
         captionEntryId: z.number().int(),
         text: z.string().nonempty(),
-        side: z.union([z.literal(0), z.literal(1)]),
+        side: z.number().refine((v) => v === 0 || v === 1),
         offset: z.number().int(),
       })
     )

--- a/app/trpc/routes/videos.ts
+++ b/app/trpc/routes/videos.ts
@@ -100,8 +100,6 @@ export const trpcRoutesVideos = {
       );
       tinyassert(video);
 
-      // TODO(perf): db index?
-      // TODO: order
       const rows = await db
         .select()
         .from(T.bookmarkEntries)

--- a/app/trpc/routes/videos.ts
+++ b/app/trpc/routes/videos.ts
@@ -79,6 +79,41 @@ export const trpcRoutesVideos = {
       return rows;
     }),
 
+  videos_getBookmarkEntries: procedureBuilder
+    .use(middlewares.requireUser)
+    .input(
+      z.object({
+        videoId: z.number().int(),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const video = await findOne(
+        db
+          .select()
+          .from(T.videos)
+          .where(
+            E.and(
+              E.eq(T.videos.id, input.videoId),
+              E.eq(T.videos.userId, ctx.user.id)
+            )
+          )
+      );
+      tinyassert(video);
+
+      // TODO(perf): db index?
+      // TODO: order
+      const rows = await db
+        .select()
+        .from(T.bookmarkEntries)
+        .where(
+          E.and(
+            E.eq(T.bookmarkEntries.userId, ctx.user.id),
+            E.eq(T.bookmarkEntries.videoId, input.videoId)
+          )
+        );
+      return rows;
+    }),
+
   videos_getLastBookmark: procedureBuilder
     .use(middlewares.requireUser)
     .input(

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -84,7 +84,10 @@ export function none<T>(): T | undefined {
   return undefined;
 }
 
-export function zip<T1, T2>(ls1: T1[], ls2: T2[]): [T1, T2][] {
+export function zip<T1, T2>(
+  ls1: readonly T1[],
+  ls2: readonly T2[]
+): [T1, T2][] {
   return range(Math.min(ls1.length, ls2.length)).map((i) => [ls1[i], ls2[i]]);
 }
 
@@ -113,4 +116,19 @@ export function findAncestorElement(
   check: (el: Element) => boolean
 ): Element | undefined {
   return findNext(el, check, (el) => el.parentElement ?? undefined);
+}
+
+// not sure if it's any useful. just a little experiment
+export function reTemplate(
+  { raw }: TemplateStringsArray,
+  ...params: string[]
+): RegExp {
+  tinyassert(raw.length === params.length + 1);
+  return new RegExp(
+    [...zip(raw, params.map(escapeRegExp)), raw.slice(-1)].flat().join("")
+  );
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -92,3 +92,25 @@ export function difference<T>(ls1: T[], ls2: T[]): T[] {
   const exclude = new Set(ls2);
   return ls1.filter((e) => !exclude.has(e));
 }
+
+function findNext<T>(
+  start: T,
+  check: (value: T) => boolean,
+  next: (value: T) => T | undefined
+): T | undefined {
+  let current: T | undefined = start;
+  while (current) {
+    if (check(current)) {
+      return current;
+    }
+    current = next(current);
+  }
+  return;
+}
+
+export function findAncestorElement(
+  el: Element,
+  check: (el: Element) => boolean
+): Element | undefined {
+  return findNext(el, check, (el) => el.parentElement ?? undefined);
+}

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -1,5 +1,4 @@
-import { range } from "@hiogawa/utils";
-import { groupBy, mapValues, tinyassert } from "@hiogawa/utils";
+import { groupBy, mapValues, range, tinyassert } from "@hiogawa/utils";
 
 export function createGetProxy(
   propHandler: (prop: string | symbol) => unknown
@@ -96,8 +95,8 @@ export function difference<T>(ls1: T[], ls2: T[]): T[] {
   return ls1.filter((e) => !exclude.has(e));
 }
 
-// not sure if it's any useful. just a little experiment
-export function reTemplate(
+// new RegExp(String.raw`...`) with only inner strings are escaped
+export function regExpRaw(
   { raw }: TemplateStringsArray,
   ...params: string[]
 ): RegExp {

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -96,28 +96,6 @@ export function difference<T>(ls1: T[], ls2: T[]): T[] {
   return ls1.filter((e) => !exclude.has(e));
 }
 
-function findNext<T>(
-  start: T,
-  check: (value: T) => boolean,
-  next: (value: T) => T | undefined
-): T | undefined {
-  let current: T | undefined = start;
-  while (current) {
-    if (check(current)) {
-      return current;
-    }
-    current = next(current);
-  }
-  return;
-}
-
-export function findAncestorElement(
-  el: Element,
-  check: (el: Element) => boolean
-): Element | undefined {
-  return findNext(el, check, (el) => el.parentElement ?? undefined);
-}
-
 // not sure if it's any useful. just a little experiment
 export function reTemplate(
   { raw }: TemplateStringsArray,


### PR DESCRIPTION
## todo

- [x] add toggle to menu (default off) (only for logged in users)
- [x] support highlighting multiple bookmarks per caption entry
- [x] fix/refactor bookmark selection
  - fixes https://github.com/hi-ogawa/ytsub-v3/issues/109
    - it turns out it was broken when selection is made by backward dragging since `Selection.anchorNode/focusNode` is flipped for such case. 
  - test on mobile
- [x] e2e
- [x] mutate query cache instead of refetch when creating a new bookmark?
- [x] spinner somewhere

## screenshots

<details>

![image](https://user-images.githubusercontent.com/4232207/235596565-0af0f1d2-954e-47e8-9be3-63a6ed6c0928.png)

</details>