### PR TITLE
feat: use url query in practice history chart

### DIFF
--- a/app/e2e/bookmarks.test.ts
+++ b/app/e2e/bookmarks.test.ts
@@ -57,9 +57,19 @@ test.describe("/bookmarks/history-chart", () => {
     await page.waitForURL("/users/signin");
   });
 
+  // prettier-ignore
   test("basic", async ({ page }) => {
     await userHook.signin(page);
     await page.goto("/bookmarks/history-chart");
     await page.getByText("this week").click();
+    await page.getByRole('button').nth(3).click();
+    await page.waitForURL(`/bookmarks/history-chart?page=1`);
+    await page.getByText("last week").click();
+    await page.getByTestId('SelectWrapper-rangeType').selectOption({ label: "by month" });
+    await page.waitForURL(`/bookmarks/history-chart?rangeType=month`);
+    await page.getByText('this month').click();
+    await page.getByRole('button').nth(3).click();
+    await page.getByText('last month').click();
+    await page.waitForURL(`/bookmarks/history-chart?rangeType=month?page=1`);
   });
 });

--- a/app/e2e/decks.test.ts
+++ b/app/e2e/decks.test.ts
@@ -75,6 +75,7 @@ test.describe("decks-seed", () => {
     await page.getByText("Added 0 to a deck").click();
   });
 
+  // prettier-ignore
   test("show-deck => pagination => deck-history", async ({ page }) => {
     await user.signin(page);
     await page.goto("/decks");
@@ -114,10 +115,12 @@ test.describe("decks-seed", () => {
     await page
       .getByTestId("SelectWrapper-rangeType")
       .selectOption({ label: "by month" });
+    await page.waitForURL(`/decks/${deckId}/history-graph?rangeType=month`);
     await page.getByText("this month").click();
     await page
       .getByTestId("SelectWrapper-graphType")
       .selectOption({ label: "by queue" });
+    await page.waitForURL(`/decks/${deckId}/history-graph?rangeType=month&graphType=queue`);
 
     //
     // /decks/$id/history

--- a/app/misc/routes.ts
+++ b/app/misc/routes.ts
@@ -87,7 +87,6 @@ export const ROUTE_DEF = {
       graphType: z.enum(["action", "queue"]).default("action"),
       rangeType: z.enum(["week", "month"]).default("week"),
       page: z.coerce.number().int().optional().default(0), // 0 => this week/month, 1 => last week/month, ...
-      now: z.coerce.date().optional(), // for testing
     }),
   },
   "/decks/$id/export": {

--- a/app/misc/routes.ts
+++ b/app/misc/routes.ts
@@ -46,7 +46,12 @@ export const ROUTE_DEF = {
       q: z.string().optional(),
     }),
   },
-  "/bookmarks/history-chart": {},
+  "/bookmarks/history-chart": {
+    query: z.object({
+      rangeType: z.enum(["week", "month"]).default("week"),
+      page: z.coerce.number().int().optional().default(0),
+    }),
+  },
   "/users/me": {},
   "/users/register": {},
   "/users/signin": {},

--- a/app/misc/routes.ts
+++ b/app/misc/routes.ts
@@ -22,6 +22,9 @@ export const Z_PAGINATION_QUERY = z.object({
   perPage: z.coerce.number().int().optional().default(20),
 });
 
+export const Z_DATE_RANGE_TYPE = z.enum(["week", "month"]);
+export type DateRangeType = z.infer<typeof Z_DATE_RANGE_TYPE>;
+
 export const ROUTE_DEF = {
   "/": {},
   "/share-target": {
@@ -48,7 +51,7 @@ export const ROUTE_DEF = {
   },
   "/bookmarks/history-chart": {
     query: z.object({
-      rangeType: z.enum(["week", "month"]).default("week"),
+      rangeType: Z_DATE_RANGE_TYPE.default("week"),
       page: z.coerce.number().int().optional().default(0),
     }),
   },
@@ -90,7 +93,7 @@ export const ROUTE_DEF = {
     params: Z_ID_PARAMS,
     query: z.object({
       graphType: z.enum(["action", "queue"]).default("action"),
-      rangeType: z.enum(["week", "month"]).default("week"),
+      rangeType: Z_DATE_RANGE_TYPE.default("week"),
       page: z.coerce.number().int().optional().default(0), // 0 => this week/month, 1 => last week/month, ...
     }),
   },

--- a/app/routes/bookmarks/history-chart.tsx
+++ b/app/routes/bookmarks/history-chart.tsx
@@ -1,19 +1,20 @@
 import { Transition } from "@headlessui/react";
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
-import { useForm } from "react-hook-form";
 import { SelectWrapper, transitionProps } from "../../components/misc";
 import { PopoverSimple } from "../../components/popover";
 import {
   EchartsComponent,
   createBookmarkHistoryChartOption,
 } from "../../components/practice-history-chart";
+import { ROUTE_DEF } from "../../misc/routes";
 import { trpc } from "../../trpc/client";
 import { useClickOutside } from "../../utils/hooks-client-utils";
+import { useTypedUrlQuery } from "../../utils/loader-utils";
 import { makeLoader } from "../../utils/loader-utils.server";
 import { cls } from "../../utils/misc";
 import type { PageHandle } from "../../utils/page-handle";
-import { DateRangeType, formatDateRange } from "../../utils/temporal-utils";
+import { formatDateRange } from "../../utils/temporal-utils";
 import { BookmarksMenuItems } from "./index";
 
 //
@@ -43,17 +44,13 @@ export const handle: PageHandle = {
 //
 
 export default function PageComponent() {
-  // TODO: use url query
-  const form = useForm<{
-    rangeType: DateRangeType;
-    page: number;
-  }>({
-    defaultValues: {
-      rangeType: "week",
-      page: 0,
-    },
-  });
-  const params = form.watch();
+  const [urlQuery, setUrlQuery] = useTypedUrlQuery(
+    ROUTE_DEF["/bookmarks/history-chart"].query
+  );
+  const params = urlQuery ?? {
+    rangeType: "week",
+    page: 0,
+  };
 
   const historyChartQuery = useQuery({
     ...trpc.bookmarks_historyChart.queryOptions(params),
@@ -89,7 +86,7 @@ export default function PageComponent() {
           <div className="flex items-center gap-2 px-2 py-1">
             <button
               className="antd-btn antd-btn-ghost i-ri-play-mini-fill w-4 h-4 rotate-[180deg]"
-              onClick={() => form.setValue("page", params.page + 1)}
+              onClick={() => setUrlQuery({ page: params.page + 1 })}
             />
             <div className="text-sm px-2">
               {formatDateRange(params.rangeType, params.page)}
@@ -100,7 +97,7 @@ export default function PageComponent() {
                 params.page === 0 &&
                   "text-colorTextDisabled pointer-events-none"
               )}
-              onClick={() => form.setValue("page", params.page - 1)}
+              onClick={() => setUrlQuery({ page: params.page - 1 })}
             />
           </div>
           <div className="flex justify-center items-center gap-2">
@@ -110,10 +107,9 @@ export default function PageComponent() {
               options={["week", "month"] as const}
               labelFn={(value) => `by ${value}`}
               value={params.rangeType}
-              onChange={(rangeType) => {
-                form.setValue("rangeType", rangeType);
-                form.setValue("page", 0);
-              }}
+              onChange={(rangeType) =>
+                setUrlQuery({ rangeType, page: undefined })
+              }
             />
           </div>
         </div>

--- a/app/routes/decks/$id/history-graph.tsx
+++ b/app/routes/decks/$id/history-graph.tsx
@@ -128,7 +128,9 @@ export default function DefaultComponent() {
               options={["week", "month"] as const}
               labelFn={(value) => `by ${value}`}
               value={params.rangeType}
-              onChange={(rangeType) => setUrlQuery({ rangeType, page: 0 })}
+              onChange={(rangeType) =>
+                setUrlQuery({ rangeType, page: undefined })
+              }
             />
             <SelectWrapper
               data-testid="SelectWrapper-graphType"

--- a/app/trpc/routes/bookmarks.ts
+++ b/app/trpc/routes/bookmarks.ts
@@ -2,8 +2,8 @@ import { mapOption, tinyassert } from "@hiogawa/utils";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import { E, T, db, findOne } from "../../db/drizzle-client.server";
+import { Z_DATE_RANGE_TYPE } from "../../misc/routes";
 import {
-  Z_DATE_RANGE_TYPE,
   fromTemporal,
   getZonedDateRange,
   toZdt,

--- a/app/trpc/routes/decks.ts
+++ b/app/trpc/routes/decks.ts
@@ -7,6 +7,7 @@ import {
 } from "../../components/practice-history-chart";
 import { E, T, db, findOne } from "../../db/drizzle-client.server";
 import { DEFAULT_DECK_CACHE, Z_PRACTICE_ACTION_TYPES } from "../../db/types";
+import { Z_DATE_RANGE_TYPE } from "../../misc/routes";
 import { importDeckJson } from "../../misc/seed-utils";
 import {
   PracticeSystem,
@@ -14,7 +15,6 @@ import {
   updateDeckCache,
 } from "../../utils/practice-system";
 import {
-  Z_DATE_RANGE_TYPE,
   fromTemporal,
   getZonedDateRange,
   toZdt,

--- a/app/utils/loader-utils.ts
+++ b/app/utils/loader-utils.ts
@@ -69,18 +69,17 @@ export function useUrlQuery() {
 export function useTypedUrlQuery<S extends z.AnyZodObject>(schema: S) {
   const [query, setQuery, toParams] = useUrlQuery();
 
-  type Input = z.input<S>;
+  type In = z.input<S>;
+  type Out = z.output<S>;
 
   const parsed = React.useMemo(() => schema.safeParse(query), [query]);
-  const typedQuery: Input | undefined = parsed.success
-    ? parsed.data
-    : undefined;
+  const typedQuery: Out | undefined = parsed.success ? parsed.data : undefined;
 
-  const setTypedQuery = (newTypedQuery: Input) => {
+  const setTypedQuery = (newTypedQuery: In) => {
     setQuery(newTypedQuery);
   };
 
-  const toTypedParams = (newTypedQuery: Input) => {
+  const toTypedParams = (newTypedQuery: In) => {
     return toParams(newTypedQuery);
   };
 

--- a/app/utils/temporal-utils.ts
+++ b/app/utils/temporal-utils.ts
@@ -1,6 +1,6 @@
 import { tinyassert, wrapError } from "@hiogawa/utils";
 import { Temporal, toTemporalInstant } from "@js-temporal/polyfill";
-import { z } from "zod";
+import type { DateRangeType } from "../misc/routes";
 import { assertUnreachable } from "./misc";
 
 export function getSystemTimezone() {
@@ -23,9 +23,6 @@ export function fromTemporal(t: { epochMilliseconds: number }): Date {
 export function isValidTimezone(timezone: string) {
   return wrapError(() => Temporal.Now.zonedDateTimeISO(timezone)).ok;
 }
-
-export const Z_DATE_RANGE_TYPE = z.enum(["week", "month"]);
-export type DateRangeType = z.infer<typeof Z_DATE_RANGE_TYPE>;
 
 export function getZonedDateRange(
   now: Temporal.ZonedDateTime,


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/ytsub-v3/pull/350

It became easier to integrate url query with client state thanks to `useTypedUrlQuery`.