### PR TITLE
[db migration] fix: add `fixBookmarkEntriesOffset` cli

### DIFF
--- a/app/e2e/videos.test.ts
+++ b/app/e2e/videos.test.ts
@@ -64,7 +64,8 @@ test.describe("videos-signed-in", () => {
 
     await page.getByText("잠깐 밖으로 나올래").evaluate((el) => {
       const selection = window.getSelection();
-      selection?.setBaseAndExtent(el.childNodes[1].childNodes[0], 2, el.childNodes[3].childNodes[0], 1);
+      // dragging in reverse direction
+      selection?.setBaseAndExtent(el.childNodes[3].childNodes[0], 1, el.childNodes[1].childNodes[0], 2);
     });
     await page.getByTestId("toast-remove").evaluate((el: any) => el.click());
     await page.locator('[data-test="new-bookmark-button"]').click();


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/ytsub-v3/issues/348

Example log when running locally: [test.log.txt](https://github.com/hi-ogawa/ytsub-v3/files/11381752/test.log.txt)


```sh
$ pnpm -s cli fixBookmarkEntriesOffset  | tee test.log.txt
...
{ stats: { total: 28, fixable: 28 } }

$ pnpm -s cli fixBookmarkEntriesOffset --update
...

$ pnpm -s cli fixBookmarkEntriesOffset
{ stats: { total: 0, fixable: 0 } }
```

## todo

- [x] `pnpm cli-staging fixBookmarkEntriesOffset --update`
- [x] `pnpm cli-production fixBookmarkEntriesOffset`
  - [test.log.txt](https://github.com/hi-ogawa/ytsub-v3/files/11381884/test.log.txt)
- [x] `pnpm cli-production fixBookmarkEntriesOffset --update`

### planetscale insight

![image](https://user-images.githubusercontent.com/4232207/235901577-85d00a1a-11ed-4dd3-8f4a-d7b9425363c4.png)
