### PR TITLE
fix: fix controlled input

### DIFF
--- a/app/routes/videos/new.tsx
+++ b/app/routes/videos/new.tsx
@@ -383,7 +383,7 @@ function AdvancedModePreviewEditor(props: {
               <div className="flex-1 p-0.5 border-r">
                 <textarea
                   className="w-full h-full p-0.5"
-                  value={t1}
+                  value={t1 ?? ""}
                   onChange={(e) => {
                     splice(i, 1, e.target.value);
                   }}


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/ytsub-v3/pull/384

It was mixing controlled/uncontrolled input and the behavior is odd when `entries1.length < entries2.length`.