### PR TITLE
chore: use prisma for schema diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "happy-dom": "^8.9.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
+    "prisma": "^4.14.0",
     "qrcode-terminal": "^0.12.0",
     "ts-prune": "^0.10.3",
     "typescript": "^4.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ devDependencies:
   prettier:
     specifier: ^2.8.4
     version: 2.8.4
+  prisma:
+    specifier: ^4.14.0
+    version: 4.14.0
   qrcode-terminal:
     specifier: ^0.12.0
     version: 0.12.0
@@ -2294,6 +2297,11 @@ packages:
 
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
+  /@prisma/engines@4.14.0:
+    resolution: {integrity: sha512-PDNlhP/1vyTgmNyiucGqGCdXIp7HIkkvKO50si3y3PcceeHvqtiKPaH1iJdz63jCWMVMbj2MElSxXPOeBvEVIQ==}
+    requiresBuild: true
     dev: true
 
   /@remix-run/dev@1.15.0(patch_hash=mbqp72oyleohhce4ih45diwqsm)(@remix-run/serve@1.15.0)(@types/node@16.11.35):
@@ -4801,7 +4809,6 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
 
   /graceful-fs@4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
@@ -5389,14 +5396,14 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
 
   /keyv@4.5.2:
     resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
@@ -6738,6 +6745,15 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       parse-ms: 2.1.0
+
+  /prisma@4.14.0:
+    resolution: {integrity: sha512-+5dMl1uxMQb4RepndY6AwR9xi1cDcaGFICu+ws6/Nmgt93mFPNj8tYxSfTdmfg+rkNrUId9rk/Ac2vTgLe/oXA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@prisma/engines': 4.14.0
+    dev: true
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,13 @@
+# prisma schema
+
+Use prisma only as a schema diff tool to auto-generate up/down migrations.
+
+```sh
+# 0. edit schema.prisma
+
+# 1. show diff for "up" migration
+npx prisma migrate diff --from-schema-datasource prisma/schema.prisma --to-schema-datamodel prisma/schema.prisma  --script
+
+# 2. show diff for "down" migration
+npx prisma migrate diff --to-schema-datasource prisma/schema.prisma --from-schema-datamodel prisma/schema.prisma  --script
+```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,8 +8,8 @@ model bookmarkEntries {
   text           String   @db.Text
   side           Int
   offset         Int
-  createdAt      DateTime @default(now()) @db.DateTime(0)
-  updatedAt      DateTime @default(now()) @db.DateTime(0)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @default(now())
   userId         BigInt
   videoId        BigInt
   captionEntryId BigInt
@@ -26,8 +26,8 @@ model captionEntries {
   end       Float    @db.Float
   text1     String   @db.Text
   text2     String   @db.Text
-  createdAt DateTime @default(now()) @db.DateTime(0)
-  updatedAt DateTime @default(now()) @db.DateTime(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
   videoId   BigInt
 
   @@index([videoId, index], map: "captionEntries_videoId_index_key")
@@ -36,8 +36,8 @@ model captionEntries {
 model decks {
   id               BigInt   @id @default(autoincrement())
   name             String   @db.Text
-  createdAt        DateTime @default(now()) @db.DateTime(0)
-  updatedAt        DateTime @default(now()) @db.DateTime(0)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @default(now())
   userId           BigInt
   newEntriesPerDay Int      @default(50)
   reviewsPerDay    Int      @default(200)
@@ -65,8 +65,8 @@ model practiceActions {
   id              BigInt   @id @default(autoincrement())
   queueType       String   @db.VarChar(32)
   actionType      String   @db.VarChar(32)
-  createdAt       DateTime @default(now()) @db.DateTime(0)
-  updatedAt       DateTime @default(now()) @db.DateTime(0)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now())
   userId          BigInt
   deckId          BigInt
   practiceEntryId BigInt
@@ -80,9 +80,9 @@ model practiceEntries {
   id                   BigInt   @id @default(autoincrement())
   queueType            String   @db.VarChar(32)
   easeFactor           Float    @db.Float
-  scheduledAt          DateTime @db.DateTime(0)
-  createdAt            DateTime @default(now()) @db.DateTime(0)
-  updatedAt            DateTime @default(now()) @db.DateTime(0)
+  scheduledAt          DateTime
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @default(now())
   deckId               BigInt
   bookmarkEntryId      BigInt
   practiceActionsCount Int      @default(0)
@@ -95,8 +95,8 @@ model users {
   id           BigInt   @id @default(autoincrement())
   username     String   @unique(map: "username") @db.VarChar(128)
   passwordHash String   @db.VarChar(128)
-  createdAt    DateTime @default(now()) @db.DateTime(0)
-  updatedAt    DateTime @default(now()) @db.DateTime(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @default(now())
   language1    String?  @db.VarChar(32)
   language2    String?  @db.VarChar(32)
   timezone     String   @default("+00:00") @db.VarChar(32)
@@ -112,8 +112,8 @@ model videos {
   title                 String   @db.Text
   author                String   @db.Text
   channelId             String   @db.VarChar(32)
-  createdAt             DateTime @default(now()) @db.DateTime(0)
-  updatedAt             DateTime @default(now()) @db.DateTime(0)
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @default(now())
   userId                BigInt?
   bookmarkEntriesCount  Int      @default(0)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,122 @@
+datasource db {
+  provider = "mysql"
+  url      = "mysql://root:password@localhost:3306/ytsub_development"
+}
+
+model bookmarkEntries {
+  id             BigInt   @id @default(autoincrement())
+  text           String   @db.Text
+  side           Int
+  offset         Int
+  createdAt      DateTime @default(now()) @db.DateTime(0)
+  updatedAt      DateTime @default(now()) @db.DateTime(0)
+  userId         BigInt
+  videoId        BigInt
+  captionEntryId BigInt
+
+  @@index([captionEntryId], map: "bookmarkEntries_captionEntryId_key")
+  @@index([userId, createdAt], map: "bookmarkEntries_userId_createdAt_key")
+  @@index([videoId], map: "bookmarkEntries_videoId_key")
+}
+
+model captionEntries {
+  id        BigInt   @id @default(autoincrement())
+  index     Int
+  begin     Float    @db.Float
+  end       Float    @db.Float
+  text1     String   @db.Text
+  text2     String   @db.Text
+  createdAt DateTime @default(now()) @db.DateTime(0)
+  updatedAt DateTime @default(now()) @db.DateTime(0)
+  videoId   BigInt
+
+  @@index([videoId, index], map: "captionEntries_videoId_index_key")
+}
+
+model decks {
+  id               BigInt   @id @default(autoincrement())
+  name             String   @db.Text
+  createdAt        DateTime @default(now()) @db.DateTime(0)
+  updatedAt        DateTime @default(now()) @db.DateTime(0)
+  userId           BigInt
+  newEntriesPerDay Int      @default(50)
+  reviewsPerDay    Int      @default(200)
+  easeMultiplier   Float    @default(2) @db.Float
+  easeBonus        Float    @default(1.5) @db.Float
+  randomMode       Boolean  @default(false)
+  cache            Json     @default(dbgenerated("(json_object())"))
+
+  @@index([userId], map: "decks_userId_key")
+}
+
+model knex_migrations {
+  id             Int       @id @default(autoincrement()) @db.UnsignedInt
+  name           String?   @db.VarChar(255)
+  batch          Int?
+  migration_time DateTime? @db.Timestamp(0)
+}
+
+model knex_migrations_lock {
+  index     Int  @id @default(autoincrement()) @db.UnsignedInt
+  is_locked Int?
+}
+
+model practiceActions {
+  id              BigInt   @id @default(autoincrement())
+  queueType       String   @db.VarChar(32)
+  actionType      String   @db.VarChar(32)
+  createdAt       DateTime @default(now()) @db.DateTime(0)
+  updatedAt       DateTime @default(now()) @db.DateTime(0)
+  userId          BigInt
+  deckId          BigInt
+  practiceEntryId BigInt
+
+  @@index([deckId, createdAt], map: "practiceActions_deckId_createdAt_key")
+  @@index([practiceEntryId], map: "practiceActions_practiceEntryId_key")
+  @@index([userId], map: "practiceActions_userId_key")
+}
+
+model practiceEntries {
+  id                   BigInt   @id @default(autoincrement())
+  queueType            String   @db.VarChar(32)
+  easeFactor           Float    @db.Float
+  scheduledAt          DateTime @db.DateTime(0)
+  createdAt            DateTime @default(now()) @db.DateTime(0)
+  updatedAt            DateTime @default(now()) @db.DateTime(0)
+  deckId               BigInt
+  bookmarkEntryId      BigInt
+  practiceActionsCount Int      @default(0)
+
+  @@index([bookmarkEntryId], map: "practiceEntries_bookmarkEntry_key")
+  @@index([deckId, scheduledAt], map: "practiceEntries_deckId_scheduledAt_key")
+}
+
+model users {
+  id           BigInt   @id @default(autoincrement())
+  username     String   @unique(map: "username") @db.VarChar(128)
+  passwordHash String   @db.VarChar(128)
+  createdAt    DateTime @default(now()) @db.DateTime(0)
+  updatedAt    DateTime @default(now()) @db.DateTime(0)
+  language1    String?  @db.VarChar(32)
+  language2    String?  @db.VarChar(32)
+  timezone     String   @default("+00:00") @db.VarChar(32)
+}
+
+model videos {
+  id                    BigInt   @id @default(autoincrement())
+  videoId               String   @db.VarChar(32)
+  language1_id          String   @db.VarChar(32)
+  language1_translation String?  @db.VarChar(32)
+  language2_id          String   @db.VarChar(32)
+  language2_translation String?  @db.VarChar(32)
+  title                 String   @db.Text
+  author                String   @db.Text
+  channelId             String   @db.VarChar(32)
+  createdAt             DateTime @default(now()) @db.DateTime(0)
+  updatedAt             DateTime @default(now()) @db.DateTime(0)
+  userId                BigInt?
+  bookmarkEntriesCount  Int      @default(0)
+
+  @@unique([videoId, language1_id, language1_translation, language2_id, language2_translation, userId], map: "videoId")
+  @@index([userId], map: "videos_userId_key")
+}


### PR DESCRIPTION
This can replace what we use skeema for.
Raw sql feels more comfortable (compared to prisma's own DSL), but it might allow easier transition to postgres if I ever wnated (neon? or supabase?).