### PR TITLE
feat: tweak cookie option

### DIFF
--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -12,6 +12,9 @@ export const initializeSessionStore = once(() => {
   sessionStore = createCookieSessionStorage({
     cookie: {
       httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      maxAge: 14 * 24 * 60 * 60, // two weeks
       secrets: [serverConfig.APP_SESSION_SECRET],
     },
   });


### PR DESCRIPTION
It turns out I didn't set `maxAge`, so I get always logged out on browser restart.