### PR TITLE
chore: tweak practice random mode

### DIFF
--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -575,7 +575,7 @@ async function debugRandomMode(rawArgs: unknown) {
         "queueType",
         "practiceActionsCount",
       ]),
-      objectPick(s, ["score", "scoreFactors"]),
+      objectPick(s, ["score"]),
     ];
     const combined = Object.assign({}, ...picked);
     return combined;

--- a/app/utils/practice-system.test.ts
+++ b/app/utils/practice-system.test.ts
@@ -206,14 +206,16 @@ describe("cache.nextEntriesRandomMode", () => {
     // build cache
     const deck1 = await loadDeck();
     expect(deck1.cache.nextEntriesRandomMode.length).toMatchInlineSnapshot(
-      "10"
+      "25"
     );
     expect(deck1.cache.nextEntriesRandomMode[0]).toBe(entry1.id);
 
     // cache shifts after action
     await system.createPracticeAction(entry1, "HARD");
     const deck2 = await loadDeck();
-    expect(deck2.cache.nextEntriesRandomMode.length).toMatchInlineSnapshot("9");
+    expect(deck2.cache.nextEntriesRandomMode.length).toMatchInlineSnapshot(
+      "24"
+    );
     expect(deck2.cache.nextEntriesRandomMode).toEqual(
       deck1.cache.nextEntriesRandomMode.slice(1)
     );


### PR DESCRIPTION
I think it would be more fun to completely remove `scheduledAt` after all.
Also increased cached entry count to 25 as it doesn't affect practice experience much but still saves some db query.