### PR TITLE
chore: fix typo in `AdvancedModeFormV2`

### DIFF
--- a/app/routes/videos/new.tsx
+++ b/app/routes/videos/new.tsx
@@ -337,7 +337,7 @@ function AdvancedModeFormV2({ videoId }: { videoId: string }) {
         type="submit"
         className={cls(
           "antd-btn antd-btn-primary p-1",
-          createMutation.isLoading && "andt-btn-loading"
+          createMutation.isLoading && "antd-btn-loading"
         )}
         disabled={!language1 || !language2 || !input}
       >


### PR DESCRIPTION
Spinner was broken due to class name typo.