### PR TITLE
chore: tweak caption editor style

### DIFF
--- a/app/components/caption-editor.tsx
+++ b/app/components/caption-editor.tsx
@@ -220,7 +220,9 @@ export function CaptionEditor(props: { videoId: string }) {
                           );
                         }}
                       ></button>
-                      <span>{stringifyTimestamp(e.begin)}</span>
+                      <span className={cls(e.begin === 0 && "text-colorError")}>
+                        {stringifyTimestamp(e.begin)}
+                      </span>
                     </div>
                     <span>-</span>
                     <div className="flex items-center gap-1.5">


### PR DESCRIPTION
Adding one more error highlight on the left side of timestamps

## screenshots

<details>

![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/2ae9df2b-6a5b-4959-8e1e-e2dc619c659a)

</details>