### PR TITLE
feat: add `ThemeLinkRelIcon`

### DIFF
--- a/app/components/theme-select.tsx
+++ b/app/components/theme-select.tsx
@@ -1,5 +1,6 @@
 import { capitalize } from "@hiogawa/utils";
 import React from "react";
+import { useMatchMedia } from "../utils/hooks-client-utils";
 import { SelectWrapper } from "./misc";
 
 // by @hiogawa/utils-experimental/dist/theme-script.global.js
@@ -65,24 +66,3 @@ const FAVICON_LIGHT =
 
 const FAVICON_DARK =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' d='M0 0h24v24H0z'%3E%3C/path%3E%3Cpath d='M18.5 10L22.9 21H20.745L19.544 18H15.454L14.255 21H12.101L16.5 10H18.5ZM10 2V4H16V6L14.0322 6.0006C13.2425 8.36616 11.9988 10.5057 10.4115 12.301C11.1344 12.9457 11.917 13.5176 12.7475 14.0079L11.9969 15.8855C10.9237 15.2781 9.91944 14.5524 8.99961 13.7249C7.21403 15.332 5.10914 16.5553 2.79891 17.2734L2.26257 15.3442C4.2385 14.7203 6.04543 13.6737 7.59042 12.3021C6.46277 11.0281 5.50873 9.57985 4.76742 8.00028L7.00684 8.00037C7.57018 9.03885 8.23979 10.0033 8.99967 10.877C10.2283 9.46508 11.2205 7.81616 11.9095 6.00101L2 6V4H8V2H10ZM17.5 12.8852L16.253 16H18.745L17.5 12.8852Z' fill='rgba(255,255,255,1)'%3E%3C/path%3E%3C/svg%3E";
-
-export function useMatchMedia(options: {
-  query: string;
-  defaultValue: boolean;
-}): boolean {
-  const result = React.useMemo(
-    () =>
-      typeof window === "undefined"
-        ? ({ matches: options.defaultValue } as MediaQueryList)
-        : window.matchMedia(options.query),
-    [options.query]
-  );
-  const rerender = React.useReducer((prev) => !prev, false)[1];
-
-  React.useEffect(() => {
-    result.addEventListener("change", rerender);
-    return () => result.removeEventListener("change", rerender);
-  }, [result]);
-
-  return result.matches;
-}

--- a/app/components/theme-select.tsx
+++ b/app/components/theme-select.tsx
@@ -35,3 +35,54 @@ globalThis.__themeStorageKey = "ytsub:theme";
 ${require("@hiogawa/utils-experimental/dist/theme-script.global.js?loader=text")}
 `;
 }
+
+// update favicon based on system color scheme regardless of app's theme in order to have a proper contrast in the browser tab list.
+export function ThemeLinkRelIcon() {
+  const [href, setHref] = React.useState(FAVICON_LIGHT);
+
+  const matches = useMatchMedia({
+    query: "(prefers-color-scheme: dark)",
+    defaultValue: false,
+  });
+
+  React.useEffect(() => {
+    setHref(matches ? FAVICON_DARK : FAVICON_LIGHT);
+  }, [matches]);
+
+  return (
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href={href}
+      suppressHydrationWarning
+    />
+  );
+}
+
+// https://remixicon.com/icon/translate-2
+const FAVICON_LIGHT =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' d='M0 0h24v24H0z'%3E%3C/path%3E%3Cpath d='M18.5 10L22.9 21H20.745L19.544 18H15.454L14.255 21H12.101L16.5 10H18.5ZM10 2V4H16V6L14.0322 6.0006C13.2425 8.36616 11.9988 10.5057 10.4115 12.301C11.1344 12.9457 11.917 13.5176 12.7475 14.0079L11.9969 15.8855C10.9237 15.2781 9.91944 14.5524 8.99961 13.7249C7.21403 15.332 5.10914 16.5553 2.79891 17.2734L2.26257 15.3442C4.2385 14.7203 6.04543 13.6737 7.59042 12.3021C6.46277 11.0281 5.50873 9.57985 4.76742 8.00028L7.00684 8.00037C7.57018 9.03885 8.23979 10.0033 8.99967 10.877C10.2283 9.46508 11.2205 7.81616 11.9095 6.00101L2 6V4H8V2H10ZM17.5 12.8852L16.253 16H18.745L17.5 12.8852Z' fill='rgba(0,0,0,1)'%3E%3C/path%3E%3C/svg%3E";
+
+const FAVICON_DARK =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' d='M0 0h24v24H0z'%3E%3C/path%3E%3Cpath d='M18.5 10L22.9 21H20.745L19.544 18H15.454L14.255 21H12.101L16.5 10H18.5ZM10 2V4H16V6L14.0322 6.0006C13.2425 8.36616 11.9988 10.5057 10.4115 12.301C11.1344 12.9457 11.917 13.5176 12.7475 14.0079L11.9969 15.8855C10.9237 15.2781 9.91944 14.5524 8.99961 13.7249C7.21403 15.332 5.10914 16.5553 2.79891 17.2734L2.26257 15.3442C4.2385 14.7203 6.04543 13.6737 7.59042 12.3021C6.46277 11.0281 5.50873 9.57985 4.76742 8.00028L7.00684 8.00037C7.57018 9.03885 8.23979 10.0033 8.99967 10.877C10.2283 9.46508 11.2205 7.81616 11.9095 6.00101L2 6V4H8V2H10ZM17.5 12.8852L16.253 16H18.745L17.5 12.8852Z' fill='rgba(255,255,255,1)'%3E%3C/path%3E%3C/svg%3E";
+
+export function useMatchMedia(options: {
+  query: string;
+  defaultValue: boolean;
+}): boolean {
+  const result = React.useMemo(
+    () =>
+      typeof window === "undefined"
+        ? ({ matches: options.defaultValue } as MediaQueryList)
+        : window.matchMedia(options.query),
+    [options.query]
+  );
+  const rerender = React.useReducer((prev) => !prev, false)[1];
+
+  React.useEffect(() => {
+    result.addEventListener("change", rerender);
+    return () => result.removeEventListener("change", rerender);
+  }, [result]);
+
+  return result.matches;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,7 +19,11 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { Drawer } from "./components/drawer";
 import { PopoverSimple } from "./components/popover";
-import { ThemeSelect, injectThemeScript } from "./components/theme-select";
+import {
+  ThemeLinkRelIcon,
+  ThemeSelect,
+  injectThemeScript,
+} from "./components/theme-select";
 import { TopProgressBarRemix } from "./components/top-progress-bar";
 import type { UserTable } from "./db/models";
 import { $R, R } from "./misc/routes";
@@ -40,7 +44,6 @@ export const links: LinksFunction = () => {
   // prettier-ignore
   return [
     { rel: "stylesheet", href: require("../build/css/index.css") },
-    { rel: "icon", href: require("./assets/icon-32.png"), sizes: "32x32" },
     { rel: "manifest", href: "/manifest.json" },
   ];
 };
@@ -78,6 +81,7 @@ export default function DefaultComponent() {
         </title>
         <Meta />
         <Links />
+        <ThemeLinkRelIcon />
         {/* only server needs to do script injection but let client do as well */}
         <script dangerouslySetInnerHTML={{ __html: injectThemeScript() }} />
         <script

--- a/app/utils/hooks-client-utils.ts
+++ b/app/utils/hooks-client-utils.ts
@@ -45,3 +45,24 @@ export function useIntersectionObserver(
     };
   });
 }
+
+export function useMatchMedia(options: {
+  query: string;
+  defaultValue: boolean;
+}): boolean {
+  const result = React.useMemo(
+    () =>
+      typeof window === "undefined"
+        ? ({ matches: options.defaultValue } as MediaQueryList)
+        : window.matchMedia(options.query),
+    [options.query]
+  );
+  const rerender = React.useReducer((prev) => !prev, false)[1];
+
+  React.useEffect(() => {
+    result.addEventListener("change", rerender);
+    return () => result.removeEventListener("change", rerender);
+  }, [result]);
+
+  return result.matches;
+}


### PR DESCRIPTION
It seems Chromium finally shipped `prefers-color-scheme` on gnome, so I noticed this little thing. 

## screenshots

<details>

![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/e4d7975d-03d5-4438-a398-66bfefbb0fac)

![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/5d7a55c4-ccee-42f7-aaaf-91b306be9d79)

![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/94571963-58f0-4ef8-b517-b5e1ade7fa82)


![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/4be6a2ae-867c-4e17-b165-9ff81ce4f0f6)


</details>