### PR TITLE
feat: add `navigateRefresh`

### DIFF
--- a/app/components/top-progress-bar.tsx
+++ b/app/components/top-progress-bar.tsx
@@ -18,5 +18,14 @@ function TopProgressBar({ loading }: { loading: boolean }) {
 
 export function TopProgressBarRemix() {
   const navigation = useNavigation();
-  return <TopProgressBar loading={navigation.state !== "idle"} />;
+  return (
+    <TopProgressBar
+      loading={
+        navigation.location?.state !== STATE_NO_PROGRESS_BAR &&
+        navigation.state !== "idle"
+      }
+    />
+  );
 }
+
+export const STATE_NO_PROGRESS_BAR = "__noProgressBar";

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,7 @@ import {
 import { RootLoaderData, useRootLoaderData } from "./utils/loader-utils";
 import { makeLoader } from "./utils/loader-utils.server";
 import { cls } from "./utils/misc";
+import { navigateRefresh } from "./utils/misc-client";
 import type { PageHandle } from "./utils/page-handle";
 import { QueryClientWrapper } from "./utils/react-query-utils";
 import { ToastWrapper } from "./utils/toast-utils";
@@ -315,13 +316,14 @@ function SignoutComponent() {
   const signoutMutation = useMutation({
     ...trpc.users_signout.mutationOptions(),
     onSuccess: () => {
-      window.location.href =
+      const href =
         $R["/"]() +
         "?" +
         encodeFlashMessage({
           variant: "success",
           content: "Successfully signed out",
         });
+      navigateRefresh(href);
     },
   });
 

--- a/app/routes/users/register.tsx
+++ b/app/routes/users/register.tsx
@@ -8,6 +8,7 @@ import { trpcClient } from "../../trpc/client-internal.client";
 import { encodeFlashMessage } from "../../utils/flash-message";
 import { makeLoader } from "../../utils/loader-utils.server";
 import { cls } from "../../utils/misc";
+import { navigateRefresh } from "../../utils/misc-client";
 import type { PageHandle } from "../../utils/page-handle";
 import { useTurnstile } from "../../utils/turnstile-utils";
 
@@ -57,13 +58,14 @@ export default function DefaultComponent() {
       });
     },
     onSuccess: () => {
-      window.location.href =
+      const href =
         $R["/"]() +
         "?" +
         encodeFlashMessage({
           variant: "success",
           content: "Successfully registered",
         });
+      navigateRefresh(href);
     },
   });
 

--- a/app/routes/users/signin.tsx
+++ b/app/routes/users/signin.tsx
@@ -5,6 +5,7 @@ import { $R } from "../../misc/routes";
 import { trpc } from "../../trpc/client";
 import { encodeFlashMessage } from "../../utils/flash-message";
 import { cls } from "../../utils/misc";
+import { navigateRefresh } from "../../utils/misc-client";
 import type { PageHandle } from "../../utils/page-handle";
 
 export const handle: PageHandle = {
@@ -22,13 +23,14 @@ export default function DefaultComponent() {
   const signinMutation = useMutation({
     ...trpc.users_signin.mutationOptions(),
     onSuccess: () => {
-      window.location.href =
+      const href =
         $R["/"]() +
         "?" +
         encodeFlashMessage({
           variant: "success",
           content: "Successfully signed in",
         });
+      navigateRefresh(href);
     },
   });
 

--- a/app/utils/flash-message.ts
+++ b/app/utils/flash-message.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from "@remix-run/react";
 import { toast } from "react-hot-toast";
 import { z } from "zod";
+import { STATE_NO_PROGRESS_BAR } from "../components/top-progress-bar";
 import { splitFirst } from "./misc";
 import { useEffectNoStrict } from "./misc-react";
 import { toastInfo } from "./toast-utils";
@@ -58,7 +59,7 @@ export function useFlashMessageHandler() {
       // remix might refetch redundantly (we can tweak shouldRevalidate if we need want to avoid that)
       const newParams = new URLSearchParams(params);
       newParams.delete(MSG_KEY);
-      setParams(newParams, { replace: true });
+      setParams(newParams, { replace: true, state: STATE_NO_PROGRESS_BAR });
     }
   }, [params]);
 }

--- a/app/utils/misc-client.tsx
+++ b/app/utils/misc-client.tsx
@@ -1,0 +1,14 @@
+import BarOfProgress from "@badrap/bar-of-progress";
+
+export function navigateRefresh(href: string) {
+  // show fading overlay to prevent further interaction
+  const overlay = document.createElement("div");
+  overlay.className = "z-100 fixed inset-0 bg-black opacity-40";
+  document.body.appendChild(overlay);
+
+  // show progress bar to indicate loading
+  new BarOfProgress({ size: 3 }).start();
+
+  // load url
+  window.location.href = href;
+}


### PR DESCRIPTION
I noticed that naive `window.location.href = ...` allows interaction while browser tries to refresh.
`navigateRefresh` works as a quick workaround around it to improve UX of the trick.