### PR TITLE
fix: fix unocss content-empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@hiogawa/isort-ts": "1.0.2-pre.1",
-    "@hiogawa/unocss-preset-antd": "2.2.1-pre.2",
+    "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
     "@iconify-json/ri": "^1.1.9",
     "@playwright/test": "^1.34.3",
     "@remix-run/dev": "1.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ devDependencies:
     specifier: 1.0.2-pre.1
     version: 1.0.2-pre.1(prettier@2.8.8)(typescript@5.1.3)
   '@hiogawa/unocss-preset-antd':
-    specifier: 2.2.1-pre.2
-    version: 2.2.1-pre.2(@unocss/preset-uno@0.52.7)(unocss@0.52.7)
+    specifier: 2.2.1-pre.3
+    version: 2.2.1-pre.3(@unocss/preset-uno@0.52.7)(unocss@0.52.7)
   '@iconify-json/ri':
     specifier: ^1.1.9
     version: 1.1.9
@@ -2161,8 +2161,8 @@ packages:
       typescript: 5.1.3
     dev: true
 
-  /@hiogawa/unocss-preset-antd@2.2.1-pre.2(@unocss/preset-uno@0.52.7)(unocss@0.52.7):
-    resolution: {integrity: sha512-IyLBst49BiscFZ+lcO1d2fJ7S7YhEK+ikgZNymtgbcMYhIbgzY6Qju4FW5BpBivQ3csMblzvgz+sfJDaXC0viw==}
+  /@hiogawa/unocss-preset-antd@2.2.1-pre.3(@unocss/preset-uno@0.52.7)(unocss@0.52.7):
+    resolution: {integrity: sha512-NjJ0uKIA6tqmDTXQkO52Hb83tBJjwjOCUx9cgodxiROjTCuEP+yfkmJyzMlDzfxRUl8DnHd8IijnZl2cAX7s9Q==}
     peerDependencies:
       '@unocss/preset-uno': '*'
       unocss: '*'

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       /^antd-spin-overlay-(\d+)$/,
       ([, size]) => `
         absolute inset-0 grid place-content-center
-        after:(content-none antd-spin h-${size})
+        after:(content-empty antd-spin h-${size})
       `,
     ],
   ],


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/ytsub-v3/pull/429
- requires https://github.com/hi-ogawa/unocss-preset-antd/pull/42

I just noticed that `and-btn-loading` and `antd-spin-overlay-xxx` is broken.
Probably unocss "fixed" something and it affected my incorrect usage of `content-xxx`.