### PR TITLE
ci: tweak npm-check-updates

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -19,7 +19,7 @@ jobs:
       - run: pnpm i
 
       # just output major change for now
-      - run: npx npm-check-updates
+      - run: npx npm-check-updates --format group
 
       # TODO: support "ignoreDeps" like renovate?
       # TODO: "--latest" to bump major?


### PR DESCRIPTION
It seems this formatting a way nicer

```sh
$ npx npm-check-updates --format group

Patch   Backwards-compatible bug fixes
 @hiogawa/utils            1.4.2-pre.11  →   1.4.2-pre.12
 @hiogawa/utils-react       1.2.1-pre.5  →    1.2.1-pre.6
 @tanstack/react-virtual  3.0.0-beta.54  →  3.0.0-alpha.0
 @trpc/client                  ^10.29.0  →       ^10.29.1
 @trpc/server                  ^10.29.0  →       ^10.29.1
 @types/react                   ^18.2.8  →        ^18.2.9
 fast-xml-parser                 ^4.2.2  →         ^4.2.4
 hono                            ^3.2.3  →         ^3.2.5
 jotai                           ^2.1.0  →         ^2.1.1

Minor   Backwards-compatible features
 @formatjs/intl                        ^2.7.2  →   ^2.8.0
 @opentelemetry/semantic-conventions  ^1.13.0  →  ^1.14.0
 @playwright/test                     ^1.34.3  →  ^1.35.0
 @remix-run/dev                        1.15.0  →   1.17.0
 @remix-run/node                       1.15.0  →   1.17.0
 @remix-run/react                      1.15.0  →   1.17.0
 @remix-run/server-runtime             1.15.0  →   1.17.0
 react-router-dom                     ^6.11.2  →  ^6.12.1

Major   Potentially breaking API changes
 @types/node  ^18.16.16  →  ^20.2.5

Major version zero   Anything may change
 @opentelemetry/sdk-node   ^0.39.1  →  ^0.40.0
 @unocss/cli               ^0.52.7  →  ^0.53.1
 @unocss/reset             ^0.52.7  →  ^0.53.1
 @vitest/coverage-c8       ^0.31.4  →  ^0.32.0
 drizzle-orm               ^0.22.0  →  ^0.26.5
 esbuild                  ^0.17.19  →  ^0.18.0
 unocss                    ^0.52.7  →  ^0.53.1
 vitest                    ^0.31.4  →  ^0.32.0
```