### PR TITLE
feat: auto session refresh

### DIFF
--- a/app/trpc/routes/users.ts
+++ b/app/trpc/routes/users.ts
@@ -63,6 +63,16 @@ export const trpcRoutesUsers = {
       return user;
     }),
 
+  users_refreshSession: procedureBuilder
+    .use(middlewares.requireUser)
+    .mutation(async ({ ctx }) => {
+      const user = await selectOne(T.users, E.eq(T.users.id, ctx.user.id));
+      tinyassert(user, "User not found");
+      signinSession(ctx.session, user);
+      await ctx.commitSession();
+      return user;
+    }),
+
   users_signout: procedureBuilder
     .use(middlewares.currentUser)
     .input(z.null())

--- a/app/utils/auth.client.ts
+++ b/app/utils/auth.client.ts
@@ -1,0 +1,5 @@
+import { trpc } from "../trpc/client";
+
+export function useCurrentUser() {
+  trpc.users_refreshSession;
+}

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -87,6 +87,7 @@ export async function getSessionUser(
   return;
 }
 
+// for testing
 // TODO: should be sync for cookie storage?
 export async function createUserCookie(user: Pick<UserTable, "id">) {
   const session = await sessionStore.getSession();


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/ytsub-v3/issues/458

Maybe also it's time to eliminate root loader's `currentUser`.
It would be more convenient if it's managed under react-query so that invalidation is simpler.
