### PR TITLE
chore: use iconify-dark icon

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -71,7 +71,7 @@ export default function DefaultComponent() {
         <link
           rel="icon"
           type="image/svg+xml"
-          href={`data:image/svg+xml;base64,${require("../public/icon.svg?loader=base64")}`}
+          href="https://iconify-dark-hiro18181.vercel.app/icon/ri/translate-2"
         />
         {/* only server needs to do script injection but let client do as well */}
         <script

--- a/remix.config.js
+++ b/remix.config.js
@@ -25,7 +25,7 @@ module.exports = {
 //
 // see patches/@remix-run__dev
 //
-globalThis.__esbuildPluginsCommon = [loaderOverridePlugin()];
+globalThis.__esbuildPluginsCommon = [];
 globalThis.__esbuildPluginsBrowser = [pureCommentPlugin()];
 globalThis.__esbuildPluginsServer = [];
 
@@ -58,41 +58,6 @@ function pureCommentPlugin() {
               loader: "tsx",
             };
           }
-        }
-      );
-    },
-  };
-}
-
-// immitate raw loader by require("some-file?loader=text")
-function loaderOverridePlugin() {
-  const fs = require("node:fs");
-
-  return {
-    name: loaderOverridePlugin.name,
-    setup(build) {
-      build.onResolve({ filter: /loader=.*/ }, (args) => {
-        return {
-          namespace: loaderOverridePlugin.name,
-          path: args.path,
-          pluginData: args,
-        };
-      });
-      build.onLoad(
-        { namespace: loaderOverridePlugin.name, filter: /.*/ },
-        async (args) => {
-          const importPath = args.path.split("?")[0];
-          const resolveDir = args.pluginData.resolveDir;
-          const resolvedPath = require.resolve(importPath, {
-            paths: [resolveDir],
-          });
-          const contents = await fs.promises.readFile(resolvedPath, "utf8");
-          const loader = args.path.split("loader=")[1];
-          return {
-            contents,
-            resolveDir,
-            loader,
-          };
         }
       );
     },


### PR DESCRIPTION
so that we don't need `loaderOverridePlugin` anymore.