### PR TITLE
refactor: simplify `wrapLoader` injection

### DIFF
--- a/app/routes/videos/index.test.ts
+++ b/app/routes/videos/index.test.ts
@@ -5,6 +5,7 @@ import { testLoader, useUserVideo } from "../../misc/test-helper";
 import { zSnapshotType } from "../../misc/test-helper-snapshot";
 import { mockRequestContext } from "../../server/request-context/mock";
 import { JSON_EXTRA } from "../../utils/json-extra";
+import { wrapLoaderV2 } from "../../utils/loader-utils.server";
 import { loader } from "./index";
 
 describe("videos/index.loader", () => {
@@ -14,7 +15,7 @@ describe("videos/index.loader", () => {
 
   it("basic", async () => {
     const res = await mockRequestContext({ user: hook.user })(() =>
-      testLoader(loader)
+      testLoader(wrapLoaderV2(loader))
     );
     tinyassert(res instanceof Response);
     const loaderData = JSON_EXTRA.deserialize(await res.json());

--- a/app/routes/videos/index.test.ts
+++ b/app/routes/videos/index.test.ts
@@ -1,7 +1,7 @@
 import { tinyassert } from "@hiogawa/utils";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { testLoader, useUserVideo } from "../../misc/test-helper";
+import { useUserVideo } from "../../misc/test-helper";
 import { zSnapshotType } from "../../misc/test-helper-snapshot";
 import { mockRequestContext } from "../../server/request-context/mock";
 import { JSON_EXTRA } from "../../utils/json-extra";
@@ -14,8 +14,8 @@ describe("videos/index.loader", () => {
   });
 
   it("basic", async () => {
-    const res = await mockRequestContext({ user: hook.user })(() =>
-      testLoader(wrapLoaderV2(loader))
+    const res = await mockRequestContext({ user: hook.user })(
+      wrapLoaderV2(loader)
     );
     tinyassert(res instanceof Response);
     const loaderData = JSON_EXTRA.deserialize(await res.json());

--- a/app/routes/videos/index.test.ts
+++ b/app/routes/videos/index.test.ts
@@ -1,7 +1,7 @@
 import { tinyassert } from "@hiogawa/utils";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { useUserVideo } from "../../misc/test-helper";
+import { testLoader, useUserVideo } from "../../misc/test-helper";
 import { zSnapshotType } from "../../misc/test-helper-snapshot";
 import { mockRequestContext } from "../../server/request-context/mock";
 import { JSON_EXTRA } from "../../utils/json-extra";
@@ -14,8 +14,8 @@ describe("videos/index.loader", () => {
   });
 
   it("basic", async () => {
-    const res = await mockRequestContext({ user: hook.user })(
-      wrapLoaderV2(loader)
+    const res = await mockRequestContext({ user: hook.user })(() =>
+      testLoader(wrapLoaderV2(loader))
     );
     tinyassert(res instanceof Response);
     const loaderData = JSON_EXTRA.deserialize(await res.json());

--- a/app/utils/loader-utils.server.ts
+++ b/app/utils/loader-utils.server.ts
@@ -17,8 +17,8 @@ export function wrapLoader(loader: () => unknown) {
 }
 
 export function wrapLoaderV2(loader: () => unknown) {
-  return async ({ params }: LoaderArgs) => {
-    ctx_get().params = params;
+  return async (args?: Partial<LoaderArgs>) => {
+    ctx_get().params = args?.params ?? {};
     const res = await loader();
     return res instanceof Response ? res : json(JSON_EXTRA.serialize(res));
   };

--- a/app/utils/loader-utils.server.ts
+++ b/app/utils/loader-utils.server.ts
@@ -17,8 +17,8 @@ export function wrapLoader(loader: () => unknown) {
 }
 
 export function wrapLoaderV2(loader: () => unknown) {
-  return async (args?: Partial<LoaderArgs>) => {
-    ctx_get().params = args?.params ?? {};
+  return async ({ params }: LoaderArgs) => {
+    ctx_get().params = params;
     const res = await loader();
     return res instanceof Response ? res : json(JSON_EXTRA.serialize(res));
   };

--- a/app/utils/loader-utils.server.ts
+++ b/app/utils/loader-utils.server.ts
@@ -8,6 +8,15 @@ import { JSON_EXTRA } from "./json-extra";
 // - setup route "params" in async context
 // - custom json serializer by default
 export function wrapLoader(loader: () => unknown) {
+  return loader;
+  // return async ({ params }: LoaderArgs) => {
+  //   ctx_get().params = params;
+  //   const res = await loader();
+  //   return res instanceof Response ? res : json(JSON_EXTRA.serialize(res));
+  // };
+}
+
+export function wrapLoaderV2(loader: () => unknown) {
   return async ({ params }: LoaderArgs) => {
     ctx_get().params = params;
     const res = await loader();


### PR DESCRIPTION
Just came up with this idea while thinking about:
- https://github.com/hi-ogawa/vite-plugins/issues/103#issuecomment-1694125297

---

Made a separate PR to replace go all in
- https://github.com/hi-ogawa/ytsub-v3/pull/493