### PR TITLE
test: simplify loader unit test

### DIFF
--- a/app/misc/test-helper.ts
+++ b/app/misc/test-helper.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { newPromiseWithResolvers, tinyassert } from "@hiogawa/utils";
-import type { LoaderFunction } from "@remix-run/server-runtime";
 import { afterAll, beforeAll } from "vitest";
 import { E, T, db } from "../db/drizzle-client.server";
 import {
@@ -9,18 +8,8 @@ import {
 } from "../db/helper";
 import type { CaptionEntryTable, UserTable, VideoTable } from "../db/models";
 import { writeCookieSession } from "../server/request-context/session";
-import { ctx_get } from "../server/request-context/storage";
 import type { NewVideo, fetchCaptionEntries } from "../utils/youtube";
 import { useUserImpl } from "./test-helper-common";
-
-export function testLoader(loader: LoaderFunction) {
-  const { request } = ctx_get();
-  return loader({
-    request,
-    context: {},
-    params: {},
-  });
-}
 
 export function useUser(...args: Parameters<typeof useUserImpl>) {
   const { before, after } = useUserImpl(...args);

--- a/app/routes/videos/index.test.ts
+++ b/app/routes/videos/index.test.ts
@@ -1,7 +1,7 @@
 import { tinyassert } from "@hiogawa/utils";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { testLoader, useUserVideo } from "../../misc/test-helper";
+import { useUserVideo } from "../../misc/test-helper";
 import { zSnapshotType } from "../../misc/test-helper-snapshot";
 import { mockRequestContext } from "../../server/request-context/mock";
 import { JSON_EXTRA } from "../../utils/json-extra";
@@ -13,9 +13,7 @@ describe("videos/index.loader", () => {
   });
 
   it("basic", async () => {
-    const res = await mockRequestContext({ user: hook.user })(() =>
-      testLoader(loader)
-    );
+    const res = await mockRequestContext({ user: hook.user })(loader);
     tinyassert(res instanceof Response);
     const loaderData = JSON_EXTRA.deserialize(await res.json());
 

--- a/app/utils/loader-utils.server.ts
+++ b/app/utils/loader-utils.server.ts
@@ -8,8 +8,9 @@ import { JSON_EXTRA } from "./json-extra";
 // - setup route "params" in async context
 // - custom json serializer by default
 export function wrapLoader(loader: () => unknown) {
-  return async ({ params }: LoaderArgs) => {
-    ctx_get().params = params;
+  // make it partial for slight convenience of unit test
+  return async (args?: Partial<LoaderArgs>) => {
+    ctx_get().params = args?.params ?? {};
     const res = await loader();
     return res instanceof Response ? res : json(JSON_EXTRA.serialize(res));
   };


### PR DESCRIPTION
After all the refactoring, `testLoader` is not really necessary.