### PR TITLE
chore(deps): replace consola with own utils

### DIFF
--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -1,9 +1,8 @@
 import { deepEqual } from "assert/strict";
 import fs from "node:fs";
 import readline from "node:readline";
-import { TinyCli, TinyCliParseError, arg, zArg } from "@hiogawa/tiny-cli";
+import { TinyCli, arg, tinyCliMain, zArg } from "@hiogawa/tiny-cli";
 import { groupBy, objectPick, range, tinyassert, zip } from "@hiogawa/utils";
-import consola from "consola";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import {
@@ -583,13 +582,7 @@ async function question(query: string): Promise<string> {
 async function main() {
   try {
     await initializeServer();
-    await cli.parse(process.argv.slice(2));
-  } catch (e) {
-    consola.error(e);
-    if (e instanceof TinyCliParseError) {
-      console.error("See '--help' for more info.");
-    }
-    process.exit(1);
+    await tinyCliMain(cli);
   } finally {
     await finalizeServer();
   }

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -1,8 +1,8 @@
 import { deepEqual } from "assert/strict";
 import fs from "node:fs";
-import readline from "node:readline";
 import { TinyCli, arg, tinyCliMain, zArg } from "@hiogawa/tiny-cli";
 import { groupBy, objectPick, range, tinyassert, zip } from "@hiogawa/utils";
+import { promptQuestion } from "@hiogawa/utils-node";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import {
@@ -249,7 +249,7 @@ cli.defineCommand(
     }
 
     while (true) {
-      const input = await question(
+      const input = await promptQuestion(
         ":: please input language (+ translation) to download (e.g. .ko, .ko_en) > "
       );
       if (!input) {
@@ -556,24 +556,6 @@ cli.defineCommand(
     console.log({ stats });
   }
 );
-
-async function question(query: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  // delegate SIGINT (cf. https://github.com/SBoudrias/Inquirer.js/pull/569)
-  rl.once("SIGINT", () => {
-    process.kill(process.pid, "SIGINT");
-  });
-  try {
-    return await new Promise((resolve) => {
-      rl.question(query, (v) => resolve(v));
-    });
-  } finally {
-    rl.close();
-  }
-}
 
 //
 // main

--- a/app/misc/cli.ts
+++ b/app/misc/cli.ts
@@ -580,12 +580,9 @@ async function question(query: string): Promise<string> {
 //
 
 async function main() {
-  try {
-    await initializeServer();
-    await tinyCliMain(cli);
-  } finally {
-    await finalizeServer();
-  }
+  await initializeServer();
+  await tinyCliMain(cli);
+  await finalizeServer();
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@hiogawa/icheck-ts": "^0.0.1-pre.2",
     "@hiogawa/isort-ts": "1.1.2-pre.0",
-    "@hiogawa/tiny-cli": "0.0.3",
+    "@hiogawa/tiny-cli": "0.0.4-pre.1",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
     "@iconify-json/ri": "^1.1.12",
     "@playwright/test": "^1.37.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@hiogawa/isort-ts": "1.1.2-pre.0",
     "@hiogawa/tiny-cli": "0.0.4-pre.1",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
+    "@hiogawa/utils-node": "0.0.1-pre.4",
     "@iconify-json/ri": "^1.1.12",
     "@playwright/test": "^1.37.1",
     "@remix-run/dev": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@vitejs/plugin-react": "^4.0.4",
     "@vitest/coverage-v8": "^0.34.3",
     "c8": "^8.0.1",
-    "consola": "^3.2.3",
     "esbuild": "^0.17.19",
     "esbuild-register": "^3.4.2",
     "express": "^4.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ devDependencies:
   c8:
     specifier: ^8.0.1
     version: 8.0.1
-  consola:
-    specifier: ^3.2.3
-    version: 3.2.3
   esbuild:
     specifier: ^0.17.19
     version: 0.17.19

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ devDependencies:
   '@hiogawa/unocss-preset-antd':
     specifier: 2.2.1-pre.3
     version: 2.2.1-pre.3(@unocss/preset-uno@0.55.3)(unocss@0.52.7)
+  '@hiogawa/utils-node':
+    specifier: 0.0.1-pre.4
+    version: 0.0.1-pre.4
   '@iconify-json/ri':
     specifier: ^1.1.12
     version: 1.1.12
@@ -2371,6 +2374,10 @@ packages:
   /@hiogawa/utils-hattip@0.0.1-pre.1:
     resolution: {integrity: sha512-kzZ6U7PZ0/m+0bYFdG+/o2F73jRgDxf3gO7Ggwr3XxDZMHH22DttQzaPre1v+kxwuSF7MQ/s8DXk5nr1SD+7hQ==}
     dev: false
+
+  /@hiogawa/utils-node@0.0.1-pre.4:
+    resolution: {integrity: sha512-r9jGKkApFk+Bwk7fSheLiopJiaStPyRt+P8RIrgQO1CVDJy0XM2Z3P6O//tX4Z6Z6JQWqdWedxHkh5c8hWNo+w==}
+    dev: true
 
   /@hiogawa/utils-react@1.3.0(react@18.2.0):
     resolution: {integrity: sha512-TqgM8pPjb+BcX+0q0MSk9mWVudKrDRKarvGsxkkyLrJrejFClxYl+4IB72VWAWvHW0qwLXJe7biW4EzyNBfMVg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ devDependencies:
     specifier: 1.1.2-pre.0
     version: 1.1.2-pre.0(prettier@2.8.8)(typescript@5.2.2)
   '@hiogawa/tiny-cli':
-    specifier: 0.0.3
-    version: 0.0.3
+    specifier: 0.0.4-pre.1
+    version: 0.0.4-pre.1
   '@hiogawa/unocss-preset-antd':
     specifier: 2.2.1-pre.3
     version: 2.2.1-pre.3(@unocss/preset-uno@0.55.3)(unocss@0.52.7)
@@ -2346,8 +2346,8 @@ packages:
       vite: 4.4.9(@types/node@18.17.11)
     dev: false
 
-  /@hiogawa/tiny-cli@0.0.3:
-    resolution: {integrity: sha512-5ZRDn0XW12mV+rov25z1oksyRP6IeW6ydEki81lHxbDEGrE/IGcrvkGTCXtbeSWIYmclNpVpuLee01KeB2jyvQ==}
+  /@hiogawa/tiny-cli@0.0.4-pre.1:
+    resolution: {integrity: sha512-3z/qYXDyROVX8oaFdqMyiLL8ZZE9dEaEw02ZYXOxmUF6U5MM3pskzLZId/KMvT+ZnLCLI4CUBuga6AIf56JXTw==}
     dev: true
 
   /@hiogawa/tiny-jwt@0.2.8-pre.2:


### PR DESCRIPTION
I was wondering how to `consola.prompt` could be implemented, and it looks like it can be replaced with own `readline.question` wrapper.
(actually this is mostly coming from https://github.com/google/zx/blob/956dcc3bbdd349ac4c41f8db51add4efa2f58456/src/goods.ts#L83)

Also updated tiny-cli to use `tinyCliMain` for simpler cli main.

## todo

- [x] use https://github.com/hi-ogawa/js-utils/pull/110