### PR TITLE
fix: explicilty set `optimizeDeps.entries` to avoid late pre-bundling full reload

### DIFF
--- a/app/e2e/auth.test.ts
+++ b/app/e2e/auth.test.ts
@@ -48,11 +48,11 @@ test.describe("/users/signin", () => {
 
   test("basic", async ({ page }) => {
     await page.goto("/");
+    await waitForHydration(page);
 
     // navigate to signin
     await page.locator("header >> data-test=login-icon").click();
     await expect(page).toHaveURL("/users/signin");
-    await waitForHydration(page);
 
     // submit form
     await page.locator('input[name="username"]').fill(user.data.username);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    // debug this by
     // DEBUG=vite:deps pnpm dev:remix --force
     entries: ["./app/entry-client.tsx", "./app/root.tsx", "./app/routes/**/*"],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,9 @@ export default defineConfig({
             ],
           }) as any;
         },
-      }),
+        // false-positive during optimizeDeps discovery
+        // https://github.com/remix-run/remix/pull/8267
+      }).filter((plugin) => plugin.name !== "remix-dot-server"),
 
     // since remix overwrites ssr build output of vitePluginSsrMiddleware,
     // we need to overwrite it back with extra plugin.
@@ -65,6 +67,10 @@ export default defineConfig({
         defaultHandler(warning);
       },
     },
+  },
+  optimizeDeps: {
+    // DEBUG=vite:deps pnpm dev:remix --force
+    entries: ["./app/entry-client.tsx", "./app/root.tsx", "./app/routes/**/*"],
   },
   test: {
     dir: "./app",


### PR DESCRIPTION
Doing the same thing as
- https://github.com/hi-ogawa/vite-plugins/pull/148

Technically this would include non-client dependencies found via `.server` files as well (e.g. `drizzle-orm` as seen in the log below), but this shouldn't break pre-bundling except it might makes things slower. It would be still possible to manually exclude by `optimizeDeps.exclude`.

<details><summary>Reveal DEBUG=vite:deps</summary>

```
$ DEBUG=vite:deps npx vite dev --force

The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
Forced re-optimization of dependencies
  vite:deps removing old cache dir /home/hiroshi/code/personal/ytsub-v3/node_modules/.vite/deps +0ms
Failed to resolve dependency: @remix-run/node, present in 'optimizeDeps.include'
  vite:deps scanning for dependencies... +0ms

  VITE v5.0.0  ready in 991 ms

  ➜  Local:   http://localhost:3000/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
  vite:deps Crawling dependencies using entries: 
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/root.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/index.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/share-target.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/share-target.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/bookmarks/_ui.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/bookmarks/history-chart.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/bookmarks/history-chart.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/bookmarks/index.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/bookmarks/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/caption-editor/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/caption-editor/watch.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/caption-editor/watch.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/import.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/index.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/new.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/new.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/debug.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/emails.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/health-check-db.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/health-check.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/knex.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/dev/stop.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/me.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/me.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/password-new.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/password-new.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/password-reset.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/register.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/register.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/signin.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/verify.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/users/verify.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/$id.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/$id.test.ts
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/$id.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/_ui.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/_utils.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/index.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/index.test.ts
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/new.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/videos/new.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/_ui.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/_utils.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/_utils.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/edit.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/export.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/export.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/history-graph.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/history.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/index.server.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/index.tsx
  vite:deps   /home/hiroshi/code/personal/ytsub-v3/app/routes/decks/$id/practice.tsx +0ms
  vite:deps Scan completed in 505.27ms: 
  vite:deps   @floating-ui/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@floating-ui+react@0.24.8_react-dom@18.2.0_react@18.2.0/node_modules/@floating-ui/react/dist/floating-ui.react.esm.js
  vite:deps   @formatjs/intl -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@formatjs+intl@2.9.6_typescript@5.2.2/node_modules/@formatjs/intl/lib/index.js
  vite:deps   @hattip/compose -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hattip+compose@0.0.34/node_modules/@hattip/compose/dist/index.js
  vite:deps   @hiogawa/argon2-wasm-bindgen/dist/worker-node -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+argon2-wasm-bindgen@0.0.6-pre.5/node_modules/@hiogawa/argon2-wasm-bindgen/dist/worker-node.js
  vite:deps   @hiogawa/json-extra -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+json-extra@0.0.2-pre.1/node_modules/@hiogawa/json-extra/dist/index.js
  vite:deps   @hiogawa/query-proxy -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+query-proxy@0.1.1-pre.3/node_modules/@hiogawa/query-proxy/dist/index.js
  vite:deps   @hiogawa/theme-script -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+theme-script@0.0.4-pre.3_vite@5.0.0/node_modules/@hiogawa/theme-script/dist/index.js
  vite:deps   @hiogawa/tiny-form/dist/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-form@0.0.1-pre.10_react@18.2.0/node_modules/@hiogawa/tiny-form/dist/react.js
  vite:deps   @hiogawa/tiny-jwt -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-jwt@0.2.8-pre.2/node_modules/@hiogawa/tiny-jwt/dist/index.js
  vite:deps   @hiogawa/tiny-progress/dist/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-progress@0.0.1-pre.4_react@18.2.0/node_modules/@hiogawa/tiny-progress/dist/react.js
  vite:deps   @hiogawa/tiny-rpc -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-rpc@0.2.3-pre.11/node_modules/@hiogawa/tiny-rpc/dist/index.js
  vite:deps   @hiogawa/tiny-store -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-store@0.0.1-pre.4_react@18.2.0/node_modules/@hiogawa/tiny-store/dist/index.js
  vite:deps   @hiogawa/tiny-store/dist/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-store@0.0.1-pre.4_react@18.2.0/node_modules/@hiogawa/tiny-store/dist/react.js
  vite:deps   @hiogawa/tiny-toast -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-toast@0.1.1-pre.10_react@18.2.0/node_modules/@hiogawa/tiny-toast/dist/index.js
  vite:deps   @hiogawa/tiny-transition/dist/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+tiny-transition@0.0.1-pre.5_react@18.2.0/node_modules/@hiogawa/tiny-transition/dist/react.js
  vite:deps   @hiogawa/utils -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+utils@1.6.1-pre.9/node_modules/@hiogawa/utils/dist/index.js
  vite:deps   @hiogawa/utils-react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@hiogawa+utils-react@1.3.1-pre.0_react@18.2.0/node_modules/@hiogawa/utils-react/dist/index.js
  vite:deps   @js-temporal/polyfill -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@js-temporal+polyfill@0.4.4/node_modules/@js-temporal/polyfill/dist/index.esm.js
  vite:deps   @opentelemetry/api -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@opentelemetry+api@1.7.0/node_modules/@opentelemetry/api/build/esm/index.js
  vite:deps   @opentelemetry/sdk-node -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@opentelemetry+sdk-node@0.45.1_patch_hash=opznjwpbsym5sugb4owpkabxrq_@opentelemetry+api@1.7.0/node_modules/@opentelemetry/sdk-node/build/src/index.js
  vite:deps   @remix-run/react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@remix-run+react@2.4.1_react-dom@18.2.0_react@18.2.0_typescript@5.2.2/node_modules/@remix-run/react/dist/esm/index.js
  vite:deps   @remix-run/server-runtime -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@remix-run+server-runtime@2.4.1_typescript@5.2.2/node_modules/@remix-run/server-runtime/dist/esm/index.js
  vite:deps   @tanstack/react-query -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@tanstack+react-query@4.36.1_react-dom@18.2.0_react@18.2.0/node_modules/@tanstack/react-query/build/lib/index.mjs
  vite:deps   @tanstack/react-query-devtools -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@tanstack+react-query-devtools@4.36.1_@tanstack+react-query@4.36.1_react-dom@18.2.0_react@18.2.0/node_modules/@tanstack/react-query-devtools/build/lib/index.mjs
  vite:deps   @tanstack/react-virtual -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/@tanstack+react-virtual@3.0.0-beta.54_react@18.2.0/node_modules/@tanstack/react-virtual/build/lib/index.mjs
  vite:deps   cookie -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/cookie@0.5.0/node_modules/cookie/index.js
  vite:deps   drizzle-orm -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/drizzle-orm@0.26.5_@opentelemetry+api@1.7.0_knex@2.5.1_mysql2@3.6.3/node_modules/drizzle-orm/index.mjs
  vite:deps   drizzle-orm/mysql-core -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/drizzle-orm@0.26.5_@opentelemetry+api@1.7.0_knex@2.5.1_mysql2@3.6.3/node_modules/drizzle-orm/mysql-core/index.mjs
  vite:deps   drizzle-orm/mysql2 -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/drizzle-orm@0.26.5_@opentelemetry+api@1.7.0_knex@2.5.1_mysql2@3.6.3/node_modules/drizzle-orm/mysql2/index.mjs
  vite:deps   echarts -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/echarts@5.4.3/node_modules/echarts/index.js
  vite:deps   fast-xml-parser -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/fast-xml-parser@4.3.2/node_modules/fast-xml-parser/src/fxp.js
  vite:deps   mysql2/promise -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/mysql2@3.6.3/node_modules/mysql2/promise.js
  vite:deps   react -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/react@18.2.0/node_modules/react/index.js
  vite:deps   showdown -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/showdown@2.1.0/node_modules/showdown/dist/showdown.js
  vite:deps   vitest -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/vitest@0.34.6_@vitest+ui@1.0.4_happy-dom@9.20.3/node_modules/vitest/dist/index.js
  vite:deps   zod -> /home/hiroshi/code/personal/ytsub-v3/node_modules/.pnpm/zod@3.22.4/node_modules/zod/lib/index.mjs +483ms
  vite:deps creating package.json in /home/hiroshi/code/personal/ytsub-v3/node_modules/.vite/deps_temp_6e26b9ae +516ms
  vite:deps Dependencies bundled in 479.77ms +481ms
```

</details>


## before

https://github.com/hi-ogawa/ytsub-v3/actions/runs/7334422695/job/19971087557#step:9:11

```
Running 34 tests using 2 workers
·······×±·····×··±·××±·±··············

Slow test file: [chromium] › auth.test.ts (48.2s)
  Slow test file: [chromium] › bookmarks.test.ts (32.9s)
  Slow test file: [chromium] › videos.test.ts (19.2s)
  Consider splitting slow test files to speed up parallel execution
  4 flaky
    [chromium] › auth.test.ts:8:5 › /users/register success ────────────────────────────────────────
    [chromium] › auth.test.ts:226:7 › reset password › logged in ───────────────────────────────────
    [chromium] › bookmarks.test.ts:39:7 › bookmarks › goToLastBookmark ─────────────────────────────
    [chromium] › bookmarks.test.ts:58:7 › /bookmarks/history-chart › requires login ────────────────
  30 passed (1.3m)
```

## after

https://github.com/hi-ogawa/ytsub-v3/actions/runs/7334549574/job/19971363131?pr=536

```
Running 34 tests using 2 workers
··································
  Slow test file: [chromium] › auth.test.ts (24.6s)
  Slow test file: [chromium] › videos.test.ts (19.6s)
  Consider splitting slow test files to speed up parallel execution
  34 passed (50.2s)
```