### PR TITLE
feat: show video title in caption-editor draft list

### DIFF
--- a/app/components/caption-editor-utils.tsx
+++ b/app/components/caption-editor-utils.tsx
@@ -42,6 +42,10 @@ export function parseManualInput(input: string): string[] {
 
 const Z_CAPTION_EDITOR_DRAFT_ITEM = z.object({
   videoId: z.string(),
+  // since only videoId was saved initially, old local storage data might not have the rest of the fields.
+  title: z.string().optional(),
+  author: z.string().optional(),
+  channelId: z.string().optional(),
 });
 
 export const Z_CAPTION_EDITOR_DRAFT_LIST = Z_CAPTION_EDITOR_DRAFT_ITEM.array();

--- a/app/e2e/videos.test.ts
+++ b/app/e2e/videos.test.ts
@@ -256,7 +256,9 @@ test("captions-editor-auto-save", async ({ page }) => {
   await page.getByTestId("Navbar-drawer-button").click();
   await page.getByRole("link", { name: "Caption Editor" }).click();
   await page.waitForURL("/caption-editor");
-  await page.getByRole("link", { name: "lH_n29wkT_4" }).click();
+  await page
+    .getByRole("link", { name: "NMIXX - PAXXWORD | SPECIAL VIDEO" })
+    .click();
   await page.waitForURL("/caption-editor/watch?v=lH_n29wkT_4");
 });
 

--- a/app/routes/caption-editor/index.tsx
+++ b/app/routes/caption-editor/index.tsx
@@ -76,7 +76,7 @@ function DraftList() {
                   v: e.videoId,
                 })}
               >
-                {e.videoId}
+                <span className="line-clamp-1">{e.title || e.videoId}</span>
               </Link>
               <button
                 className="antd-btn antd-btn-ghost i-ri-close-line w-5 h-5"

--- a/app/routes/caption-editor/watch.tsx
+++ b/app/routes/caption-editor/watch.tsx
@@ -46,7 +46,9 @@ function PageInner() {
         defaultValue={draftData}
         onChange={(data) => {
           setDraftData(data);
-          setDraftList(uniqBy([...draftList, { videoId }], (e) => e.videoId));
+          setDraftList(
+            uniqBy([...draftList, videoMetadata.videoDetails], (e) => e.videoId)
+          );
         }}
       />
     </div>


### PR DESCRIPTION
Not sure why I haven't done yet, but it seems totally fine.

## screenshots

![image](https://github.com/hi-ogawa/ytsub-v3/assets/4232207/82c42cc5-148c-4574-bf04-562491889a43)
