### PR TITLE
chore: temporary shutdown

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - run: corepack enable
       - run: pnpm i
       - run: pnpm build
-      - run: npm i -g vercel@33.0.1
+      - run: npm i -g vercel@latest
       - run: bash misc/vercel/auth-ci.sh
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - run: corepack enable
       - run: pnpm i
       - run: pnpm build
-      - run: npm i -g vercel@latest
+      - run: npm i -g vercel@33.0.1
       - run: bash misc/vercel/auth-ci.sh
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ytsub-v3
 
+> [!note]
+> Currently the application is shutdown as Planetscale closed a hobby plan.
+
+https://ytsub-v3-hiro18181.vercel.app
+
 ```sh
 # development
 pnpm i

--- a/misc/vercel/config.json
+++ b/misc/vercel/config.json
@@ -4,7 +4,7 @@
     {
       "src": "^/(.*)$",
       "status": 307,
-      "headers": { "Location": "https://github.com/hi-ogawa/ytsub-v3/pull/562" }
+      "headers": { "location": "https://github.com/hi-ogawa/ytsub-v3" }
     },
     {
       "src": "^/assets/(.*)$",

--- a/misc/vercel/config.json
+++ b/misc/vercel/config.json
@@ -2,6 +2,11 @@
   "version": 3,
   "routes": [
     {
+      "src": "^/(.*)$",
+      "status": 307,
+      "headers": { "Location": "https://github.com/hi-ogawa/ytsub-v3/pull/562" }
+    },
+    {
       "src": "^/assets/(.*)$",
       "headers": {
         "cache-control": "public, immutable, max-age=31536000"


### PR DESCRIPTION
For now, we made a redirection:

```
$ curl -X GET -I https://ytsub-v3-hiro18181.vercel.app/
HTTP/2 307 
cache-control: public, max-age=0, must-revalidate
content-type: text/plain
date: Thu, 04 Apr 2024 08:04:45 GMT
location: https://github.com/hi-ogawa/ytsub-v3
server: Vercel
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-vercel-id: hnd1::z2g2s-1712217885102-90b74f13013f
```